### PR TITLE
Replace keyframes with segments

### DIFF
--- a/crates/motiongfx_engine/src/action.rs
+++ b/crates/motiongfx_engine/src/action.rs
@@ -25,6 +25,9 @@ impl<T, U> ActionFn<T> for U where U: Fn(&T) -> T + ThreadSafe {}
 pub struct RelatedActions(Vec<Entity>);
 
 /// The target entity that this [`Action`] belongs to.
+///
+/// In other words, the entity that is going to be animated
+/// by this [`Action`].
 #[derive(
     Component, Reflect, Deref, Debug, Clone, Copy, PartialEq, Eq, Hash,
 )]
@@ -172,7 +175,7 @@ impl<'w> ActionBuilderExt<'w> for EntityCommands<'w> {
         let action_target = ActionTarget(self.id());
         ActionBuilder::new(self.commands_mut().spawn((
             action_target,
-            field.to_hash(),
+            field,
             Action::new(action),
         )))
     }

--- a/crates/motiongfx_engine/src/field.rs
+++ b/crates/motiongfx_engine/src/field.rs
@@ -111,7 +111,7 @@ pub use field_bundle;
 pub struct Field<Source, Target> {
     /// The path of the field in the source.
     /// (e.g. `Transform::translation::x` will have
-    /// a field path of "::translation::x").
+    /// a field path of `"::translation::x"`).
     ///
     /// You can achieved this using [`stringify!`].
     pub field_path: &'static str,
@@ -131,6 +131,7 @@ impl<Source, Target> Field<Source, Target>
 where
     Source: 'static,
 {
+    /// Converts into a [`FieldHash`] type.
     pub fn to_hash(&self) -> FieldHash {
         FieldHash::new::<Source>(self.field_path)
     }
@@ -195,7 +196,7 @@ impl<Source, Target> FieldBuilder<Source, Target> {
     }
 }
 
-/// Creates a [`Field`] with type and path safety.
+/// Creates a [`Field`] with path safety.
 #[macro_export]
 macro_rules! field {
     (<$source:ty>$(::$field:tt)*) => {
@@ -258,7 +259,7 @@ where
     }
 }
 
-/// Creates a [`FieldHash`] without type safety.
+/// Creates a [`FieldHash`] without path safety.
 ///
 /// Use [`field!`] for the type safe version.
 #[macro_export]
@@ -278,9 +279,9 @@ macro_rules! stringify_field {
     };
 }
 
-/// Creates a [`FieldHash`] with type safety.
+/// Creates a [`FieldHash`] with path safety.
 ///
-/// Use [`field_hash_raw!`] for the non type safe version.
+/// Use [`field_hash_raw!`] for the non path safe version.
 #[macro_export]
 macro_rules! field_hash {
     (<$source:ty>$(::$field:tt)+) => {

--- a/crates/motiongfx_engine/src/sequence.rs
+++ b/crates/motiongfx_engine/src/sequence.rs
@@ -2,7 +2,7 @@ use bevy::asset::AsAssetId;
 use bevy::ecs::component::Mutable;
 use bevy::prelude::*;
 use segment::{
-    bake_asset_keyframes, bake_component_keyframes,
+    bake_asset_actions, bake_component_actions,
     sample_asset_keyframes, sample_component_keyframes,
 };
 use smallvec::SmallVec;
@@ -66,7 +66,7 @@ impl AnimateAppExt for App {
             sample_component_keyframes(field_bundle.field)
                 .in_set(MotionGfxSet::Sample),
         )
-        .add_observer(bake_component_keyframes(field_bundle.field))
+        .add_observer(bake_component_actions(field_bundle.field))
         .register_field(field_bundle)
     }
 
@@ -83,7 +83,7 @@ impl AnimateAppExt for App {
             sample_asset_keyframes::<Source, _>(field_bundle.field)
                 .in_set(MotionGfxSet::Sample),
         )
-        .add_observer(bake_asset_keyframes::<Source, _>(
+        .add_observer(bake_asset_actions::<Source, _>(
             field_bundle.field,
         ))
         .register_field(field_bundle)

--- a/crates/motiongfx_engine/src/sequence.rs
+++ b/crates/motiongfx_engine/src/sequence.rs
@@ -1,7 +1,7 @@
 use bevy::asset::AsAssetId;
 use bevy::ecs::component::Mutable;
 use bevy::prelude::*;
-use keyframe::{
+use segment::{
     bake_asset_keyframes, bake_component_keyframes,
     sample_asset_keyframes, sample_component_keyframes,
 };
@@ -12,7 +12,7 @@ use crate::field::{FieldBundle, RegisterFieldAppExt};
 use crate::prelude::Interpolation;
 use crate::{MotionGfxSet, ThreadSafe};
 
-pub mod keyframe;
+pub mod segment;
 pub mod track;
 
 pub(super) struct SequencePlugin;
@@ -21,7 +21,7 @@ impl Plugin for SequencePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
             track::TrackPlugin,
-            keyframe::KeyframePlugin,
+            segment::KeyframePlugin,
         ));
 
         app.add_systems(

--- a/crates/motiongfx_engine/src/sequence.rs
+++ b/crates/motiongfx_engine/src/sequence.rs
@@ -129,24 +129,22 @@ fn update_curr_time(
     }
 }
 
-// TODO: Remove this as a component?
-// Add type wrappers to them. e.g. Slide, Timeline..
-
 /// A group of actions in chronological order.
 #[derive(Component, Default, Clone)]
 #[require(SequenceController)]
 #[component(immutable)]
 pub struct Sequence {
-    duration: f32,
     /// Stores the [`ActionSpan`]s that makes up the sequence.
     pub(crate) spans: SmallVec<[ActionSpan; 1]>,
+    /// The duration of the entire sequence, accumulated from `spans`.
+    duration: f32,
 }
 
 impl Sequence {
     pub fn single(span: ActionSpan) -> Self {
-        let duration = span.duration();
         let mut spans = SmallVec::new();
         spans.push(span);
+        let duration = span.duration();
 
         Self { spans, duration }
     }

--- a/crates/motiongfx_engine/src/sequence/track.rs
+++ b/crates/motiongfx_engine/src/sequence/track.rs
@@ -104,6 +104,7 @@ impl Track {
 
     fn push_span(&mut self, span_id: usize, span: &ActionSpan) {
         self.span_ids.push(span_id);
+        // Push the end time further down.
         self.end_time = span.end_time();
     }
 


### PR DESCRIPTION
# Goal

This switch allows for more dynamic use cases like repetitions, and most importantly slides.

A track with keyframes while memory efficient, poses an issue on spontaneous actions (with 0.0 duration) when it comes to generating slides. This issue arises when there's 2 spontaneous actions (A and B) are placed side by side, but on different slide (A: slide0, B: slide1). In a track, this poses an issue, because of floating point inaccuracy in addition to the ambiguous return index of a binary search algorithm, we do not know the bounds of which keyframe belongs to which slide in a continuous track.

The solution boils down to this, either:

1. Embed the slide index in each and every keyframe, or ...
2. Bake each action into a segment consisting of start and end value

Because we are at option 2, this means we get to keep our single source of truth and reduce the additional memory footprint and all the syncing check for making sure that the slide index is indeed assigned correctly to the keyframes.