### PR TITLE
Jaghov/instant animations

### DIFF
--- a/crates/motiongfx/src/action.rs
+++ b/crates/motiongfx/src/action.rs
@@ -421,7 +421,10 @@ impl<T> InterpActionBuilder<'_, T> {
     pub fn play(self, duration: f32) -> TrackFragment {
         TrackFragment::single(
             self.inner.key,
-            ActionClip::new(self.id(), duration),
+            ActionClip::new(
+                self.id(),
+                duration.max(f32::MIN_POSITIVE),
+            ),
         )
     }
 }

--- a/crates/motiongfx/src/action.rs
+++ b/crates/motiongfx/src/action.rs
@@ -427,6 +427,11 @@ impl<T> InterpActionBuilder<'_, T> {
             ),
         )
     }
+    /// Plays an animation instantaneously (shorthand for [`Self::play`]\ (0.0))
+    #[inline]
+    pub fn instant(self) -> TrackFragment {
+        self.play(0.0)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Purpose:
Addresses #108

## Original Issue
instant animations of the form:
```rust
let instant_frag = b.act(id, path!(..), move |_| x).play(0.0);
```
Had an issue of creating sequences where the start and the end had the exact same time.

## Solution
Ensure the start and end values aren't the same by adding a small delta to the duration before constructing an `ActionClip` with a minimum duration of delta = f32::MIN_POSITIVE.