### PR TITLE
Take `Tracks` in `TimelineBuilder::compile`

### DIFF
--- a/crates/bevy_motiongfx/README.md
+++ b/crates/bevy_motiongfx/README.md
@@ -56,8 +56,7 @@ fn build_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     // Spawn the timeline.
     commands.spawn(motiongfx.add_timeline(timeline));
@@ -93,8 +92,7 @@ fn build_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     // Spawn the timeline.
     commands.spawn(motiongfx.add_timeline(timeline));
@@ -116,8 +114,9 @@ fn build_timeline(
 ) {
     // Build the timeline.
     let mut b = motiongfx.create_builder();
-    // Add tracks here...
-    let timeline = b.compile();
+    // Add actions here...
+    let track = TrackFragment::new().compile();
+    let timeline = b.compile(track);
 
     // Spawn the timeline with a controller.
     commands.spawn((

--- a/crates/motiongfx/README.md
+++ b/crates/motiongfx/README.md
@@ -66,8 +66,7 @@ let frag = action.play(s(1));
 // See "Track Ordering" section for composing fragments.
 let track = frag.compile();
 
-b.add_tracks(track);
-let mut timeline = b.compile();
+let mut timeline = b.compile(track);
 
 // Bake must run once before sampling.
 timeline.bake_actions(&registry, &world);
@@ -171,8 +170,7 @@ let frag = action.play(s(1));
 let track = frag.compile();
 
 // Add the track and compile into a Timeline.
-b.add_tracks(track);
-let timeline = b.compile();
+let timeline = b.compile(track);
 ```
 
 ### Bake and Sample

--- a/crates/motiongfx/benches/action_storage.rs
+++ b/crates/motiongfx/benches/action_storage.rs
@@ -85,8 +85,7 @@ fn build_timeline(
         })
         .collect::<Vec<_>>();
 
-    builder.add_tracks(fragments.ord_all().compile());
-    builder.compile()
+    builder.compile(fragments.ord_all().compile())
 }
 
 fn bench_build(c: &mut Criterion) {
@@ -318,8 +317,7 @@ fn build_mixed(
         })
         .collect::<Vec<_>>();
 
-    builder.add_tracks(fragments.ord_all().compile());
-    builder.compile()
+    builder.compile(fragments.ord_all().compile())
 }
 
 fn bench_mixed_build(c: &mut Criterion) {

--- a/crates/motiongfx/docs/world.rs
+++ b/crates/motiongfx/docs/world.rs
@@ -24,7 +24,6 @@ pub fn timeline() -> (Registry, Timeline<World>) {
         .with_interp(|a: &f32, b: &f32, t| a + (b - a) * t)
         .play(s(1))
         .compile();
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     (registry, timeline)
 }

--- a/crates/motiongfx/examples/custom_world.rs
+++ b/crates/motiongfx/examples/custom_world.rs
@@ -89,8 +89,7 @@ fn main() {
     .ord_chain();
 
     // Compile into a timeline.
-    builder.add_tracks(track.compile());
-    let mut timeline = builder.compile();
+    let mut timeline = builder.compile(track.compile());
 
     // Bake actions into segments.
     timeline.bake_actions(&world.registry, &world.subject_world);

--- a/crates/motiongfx/src/lib.rs
+++ b/crates/motiongfx/src/lib.rs
@@ -19,6 +19,9 @@ pub mod world;
 
 // Re-exports field_path as it is essential for motiongfx to work!
 pub use field_path;
+// Re-exported so `Tracks` can be built without depending on `nonempty`
+// directly.
+pub use ::nonempty;
 
 pub mod prelude {
     pub use field_path::field_accessor::FieldAccessor;
@@ -30,6 +33,7 @@ pub mod prelude {
     };
     pub use crate::ease;
     pub use crate::interpolation::Interpolation;
+    pub use crate::nonempty::{self, nonempty};
     pub use crate::path;
     pub use crate::pipeline::PipelineKey;
     pub use crate::registry::{
@@ -37,7 +41,9 @@ pub mod prelude {
     };
     pub use crate::time::{cs, ms, ns, s};
     pub use crate::timeline::{Timeline, TimelineBuilder};
-    pub use crate::track::{Track, TrackFragment, TrackOrdering};
+    pub use crate::track::{
+        Track, TrackFragment, TrackOrdering, Tracks,
+    };
     pub use crate::world::SubjectSource;
 }
 

--- a/crates/motiongfx/src/lib.rs
+++ b/crates/motiongfx/src/lib.rs
@@ -19,7 +19,7 @@ pub mod world;
 
 // Re-exports field_path as it is essential for motiongfx to work!
 pub use field_path;
-// Re-exported so `Tracks` can be built without depending on `nonempty`
+// Re-exported so `TrackList` can be built without depending on `nonempty`
 // directly.
 pub use ::nonempty;
 
@@ -42,7 +42,7 @@ pub mod prelude {
     pub use crate::time::{cs, ms, ns, s};
     pub use crate::timeline::{Timeline, TimelineBuilder};
     pub use crate::track::{
-        Track, TrackFragment, TrackOrdering, Tracks,
+        Track, TrackFragment, TrackList, TrackOrdering,
     };
     pub use crate::world::SubjectSource;
 }

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -16,7 +16,7 @@ use crate::interpolation::Interpolation;
 use crate::pipeline::{BakeCtx, PipelineKey, Range, SampleCtx};
 use crate::registry::Registry;
 use crate::subject::SubjectId;
-use crate::track::Track;
+use crate::track::{Track, Tracks};
 use crate::world::SubjectSource;
 
 pub struct Timeline<W> {
@@ -445,7 +445,6 @@ pub struct TimelineBuilder<'a, W> {
     registry: &'a mut Registry,
     action_table: ActionTable,
     pipeline_counts: HashMap<PipelineKey, u32>,
-    tracks: Vec<Track>,
     _marker: PhantomData<fn() -> W>,
 }
 
@@ -456,7 +455,6 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
             registry,
             action_table: ActionTable::new(),
             pipeline_counts: HashMap::new(),
-            tracks: Vec::new(),
             _marker: PhantomData,
         }
     }
@@ -559,35 +557,15 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
         false
     }
 
-    /// Add [`Track`]\(s\) to the timeline.
-    pub fn add_tracks(
-        &mut self,
-        tracks: impl IntoIterator<Item = Track>,
-    ) {
-        self.tracks.extend(tracks);
-    }
-
     /// Compile into a [`Timeline`].
-    ///
-    /// ## Panic
-    ///
-    /// Panics if the track is empty.
-    /// Use [`Self::try_compile`] to explicitly handle the case where
-    /// the track may be empty.
-    pub fn compile(self) -> Timeline<W> {
-        // TODO(nixon): What happens when track is empty?
-        debug_assert!(
-            !self.tracks.is_empty(),
-            "Track cannot be empty!"
-        );
-
+    pub fn compile(self, tracks: impl Into<Tracks>) -> Timeline<W> {
         Timeline {
             action_table: self.action_table,
             pipeline_counts: self
                 .pipeline_counts
                 .into_iter()
                 .collect(),
-            tracks: self.tracks.into_boxed_slice(),
+            tracks: tracks.into().into_boxed_slice(),
             queue_cache: QueueCache::new(),
             sample_queue: HashMap::new(),
             curr_time: Duration::ZERO,
@@ -596,12 +574,6 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
             target_index: 0,
             _marker: PhantomData,
         }
-    }
-
-    /// Similar to [`Self::compile`] but return `None` instead of
-    /// panicking.
-    pub fn try_compile(self) -> Option<Timeline<W>> {
-        (!self.tracks.is_empty()).then(|| self.compile())
     }
 }
 

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -16,7 +16,7 @@ use crate::interpolation::Interpolation;
 use crate::pipeline::{BakeCtx, PipelineKey, Range, SampleCtx};
 use crate::registry::Registry;
 use crate::subject::SubjectId;
-use crate::track::{Track, Tracks};
+use crate::track::{Track, TrackList};
 use crate::world::SubjectSource;
 
 pub struct Timeline<W> {
@@ -558,7 +558,10 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
     }
 
     /// Compile into a [`Timeline`].
-    pub fn compile(self, tracks: impl Into<Tracks>) -> Timeline<W> {
+    pub fn compile(
+        self,
+        tracks: impl Into<TrackList>,
+    ) -> Timeline<W> {
         Timeline {
             action_table: self.action_table,
             pipeline_counts: self

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use field_path::field::UntypedField;
 use hashbrown::HashMap;
+use nonempty::NonEmpty;
 
 use crate::action::{ActionClip, ActionKey};
 use crate::sequence::Sequence;
@@ -365,6 +366,39 @@ impl IntoIterator for Track {
 
     fn into_iter(self) -> Self::IntoIter {
         [self].into_iter()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Tracks(pub NonEmpty<Track>);
+
+impl From<Track> for Tracks {
+    fn from(track: Track) -> Self {
+        Self::new(track)
+    }
+}
+
+impl Tracks {
+    pub fn new(track: Track) -> Self {
+        Self(NonEmpty::new(track))
+    }
+
+    pub fn collect(
+        tracks: impl IntoIterator<Item = Track>,
+    ) -> Option<Self> {
+        NonEmpty::collect(tracks).map(Self)
+    }
+
+    pub fn add(
+        &mut self,
+        tracks: impl IntoIterator<Item = Track>,
+    ) -> &mut Self {
+        self.0.extend(tracks);
+        self
+    }
+
+    pub fn into_boxed_slice(self) -> Box<[Track]> {
+        self.0.into_iter().collect()
     }
 }
 

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -369,16 +369,18 @@ impl IntoIterator for Track {
     }
 }
 
+/// The [`Track`]s a [`Timeline`](crate::timeline::Timeline) plays
+/// through, always at least one.
 #[derive(Clone, Debug)]
-pub struct Tracks(pub NonEmpty<Track>);
+pub struct TrackList(pub NonEmpty<Track>);
 
-impl From<Track> for Tracks {
+impl From<Track> for TrackList {
     fn from(track: Track) -> Self {
         Self::new(track)
     }
 }
 
-impl Tracks {
+impl TrackList {
     pub fn new(track: Track) -> Self {
         Self(NonEmpty::new(track))
     }

--- a/crates/motiongfx_scene/src/compile.rs
+++ b/crates/motiongfx_scene/src/compile.rs
@@ -37,9 +37,8 @@ impl<B: SceneBackend> Scene<B> {
         )?;
 
         let track = root_fragment.compile();
-        builder.add_tracks([track]);
 
-        builder.try_compile().ok_or(CompileError::EmptyTimeline)
+        Ok(builder.compile(track))
     }
 
     /// Writes the [`Stage`](crate::scene::Stage)'s initial values into

--- a/crates/motiongfx_scene/src/error.rs
+++ b/crates/motiongfx_scene/src/error.rs
@@ -50,9 +50,6 @@ pub enum CompileError<B: SceneBackend> {
         type_name: &'static str,
         field: FieldRef,
     },
-
-    /// The builder produced no tracks, so there is nothing to play.
-    EmptyTimeline,
 }
 
 // Manual Display to keep the crate `no_std` + `alloc`.
@@ -97,9 +94,6 @@ impl<B: SceneBackend> fmt::Display for CompileError<B> {
                     field.type_name(),
                     field.path()
                 )
-            }
-            Self::EmptyTimeline => {
-                write!(f, "scene compiled to an empty timeline")
             }
         }
     }

--- a/editor/motiongfx_editor/src/main.rs
+++ b/editor/motiongfx_editor/src/main.rs
@@ -75,9 +75,8 @@ fn spawn_timeline(
         .ord_flow(cs(10));
 
     let track = [grow, spin].ord_chain().compile();
-    b.add_tracks(track);
 
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         // Start paused; drive playback from the editor.

--- a/examples/bevy_examples/examples/custom_ease.rs
+++ b/examples/bevy_examples/examples/custom_ease.rs
@@ -43,9 +43,7 @@ fn spawn_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/custom_interp.rs
+++ b/examples/bevy_examples/examples/custom_interp.rs
@@ -45,9 +45,7 @@ fn spawn_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/easings.rs
+++ b/examples/bevy_examples/examples/easings.rs
@@ -98,9 +98,9 @@ fn spawn_timeline(
         })
         .ord_chain();
 
-    b.add_tracks(track.compile());
+    let tracks = track.compile();
 
-    let timeline = b.compile();
+    let timeline = b.compile(tracks);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/hello_world.rs
+++ b/examples/bevy_examples/examples/hello_world.rs
@@ -93,8 +93,7 @@ fn spawn_timeline(
     }
 
     let track = cube_tracks.ord_flow(cs(1)).compile();
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     commands.spawn((
         motiongfx.add_timeline(timeline),

--- a/examples/bevy_examples/examples/minimal.rs
+++ b/examples/bevy_examples/examples/minimal.rs
@@ -65,8 +65,7 @@ fn build_timeline(
     .ord_all()
     .compile();
 
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     // Spawns the timeline and start playing.
     commands.spawn((

--- a/examples/bevy_examples/examples/recording.rs
+++ b/examples/bevy_examples/examples/recording.rs
@@ -115,9 +115,7 @@ fn spawn_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         FixedRatePlayer::new(144),

--- a/examples/bevy_examples/examples/slide_basic.rs
+++ b/examples/bevy_examples/examples/slide_basic.rs
@@ -83,7 +83,7 @@ fn spawn_timeline(
     .ord_flow(cs(10))
     .compile();
 
-    let timeline = b.compile(Tracks(nonempty![slide0, slide1]));
+    let timeline = b.compile(TrackList(nonempty![slide0, slide1]));
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/slide_basic.rs
+++ b/examples/bevy_examples/examples/slide_basic.rs
@@ -83,9 +83,7 @@ fn spawn_timeline(
     .ord_flow(cs(10))
     .compile();
 
-    b.add_tracks([slide0, slide1]);
-
-    let timeline = b.compile();
+    let timeline = b.compile(Tracks(nonempty![slide0, slide1]));
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/vello_winit_example/examples/lissajous.rs
+++ b/examples/vello_winit_example/examples/lissajous.rs
@@ -223,7 +223,7 @@ impl LissajousTableDemo {
             .ord_flow(STAGGER)
             .compile();
         let mut timeline =
-            b.compile(Tracks(nonempty![grid_track, curve_track]));
+            b.compile(TrackList(nonempty![grid_track, curve_track]));
         timeline.bake_actions(&registry, &world);
         let grid_duration = timeline.tracks()[0].duration();
         let curve_duration = timeline.tracks()[1].duration();

--- a/examples/vello_winit_example/examples/lissajous.rs
+++ b/examples/vello_winit_example/examples/lissajous.rs
@@ -185,7 +185,6 @@ impl LissajousTableDemo {
         }
         let grid_track =
             pair_tracks.into_iter().ord_flow(cs(5)).compile();
-        b.add_tracks(grid_track);
 
         // Track 1: curves draw in and out, looped by the caller.
         let max_diag = N_X + N_Y;
@@ -223,9 +222,8 @@ impl LissajousTableDemo {
             })
             .ord_flow(STAGGER)
             .compile();
-        b.add_tracks(curve_track);
-
-        let mut timeline = b.compile();
+        let mut timeline =
+            b.compile(Tracks(nonempty![grid_track, curve_track]));
         timeline.bake_actions(&registry, &world);
         let grid_duration = timeline.tracks()[0].duration();
         let curve_duration = timeline.tracks()[1].duration();


### PR DESCRIPTION
Follows the builder no longer accumulating tracks itself. `Tracks` wraps a `NonEmpty<Track>`, so a timeline can't be built with zero tracks, and `compile` takes `impl Into<Tracks>` with a `From<Track>` impl so the single-track case stays `b.compile(track)`.

Multiple tracks go through `Tracks(nonempty![a, b])`, with `nonempty` re-exported from `motiongfx` so callers don't depend on it directly.

`CompileError::EmptyTimeline` goes with it - the type now rules that case out, leaving the variant unconstructible.