### PR TITLE
Show parent children relationship in hierarchy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["crates/*", "editor/*", "examples/*", ]
-exclude = ["editor/assets"]
+exclude = ["editor/assets", "editor/docs"]
 
 [workspace.package]
 version = "0.3.0"

--- a/crates/bevy_motiongfx/src/scene/id.rs
+++ b/crates/bevy_motiongfx/src/scene/id.rs
@@ -41,6 +41,7 @@ use tracing::error;
 )]
 #[reflect(Component, Hash, PartialEq)]
 #[serde(transparent)]
+#[require(Name = Name("Unamed Entity".into()))]
 pub struct EntityUid(Uuid);
 
 impl EntityUid {

--- a/editor/docs/backlog.md
+++ b/editor/docs/backlog.md
@@ -1,0 +1,22 @@
+# Backlog
+
+## Unify theming onto `EditorTheme`
+
+`EditorTheme` (our Monokai Pro palette) and feathers' `UiTheme`
+currently coexist. `UiTheme` only colors the stock feathers widgets we
+reuse - `NumberField`'s input and the dropdown popup - which likely
+look mismatched against the rest of the UI. Their own systems read
+`UiTheme` every frame for hover/press/focus, so patching tokens still
+leaves a second theme mechanism underneath; owning the widgets is the
+only way both surfaces read one palette. Fork feathers and rebuild
+those as moxie_ui elements styled off `EditorTheme`, then drop
+`UiTheme`/`ThemeProps`/feathers tokens once nothing reads them.
+
+- [ ] Fork feathers; build our own `NumberField` (drag/type/format
+      interaction) as a moxie_ui element, styled off `EditorTheme`.
+- [ ] Build our own dropdown popup (placement, dismissal, keyboard
+      nav) as a moxie_ui element, styled off `EditorTheme`.
+- [ ] Drop `UiTheme`/`ThemeProps`/feathers tokens once nothing reads
+      them.
+- [ ] `Label`'s `None => ThemedText` fallback should default to
+      `theme.text_primary` directly.

--- a/editor/moxie/src/lib.rs
+++ b/editor/moxie/src/lib.rs
@@ -74,6 +74,10 @@ pub(crate) struct EditorState {
 #[derive(Resource, Default, Clone, PartialEq)]
 pub(crate) struct SelectedAction(pub(crate) Option<Vec<usize>>);
 
+/// The entity currently selected in the hierarchy panel, if any.
+#[derive(Resource, Default, Clone, Copy, PartialEq)]
+pub(crate) struct SelectedEntity(pub(crate) Option<Entity>);
+
 #[derive(Debug, Resource, SettingsGroup, Reflect)]
 #[reflect(Resource, SettingsGroup, Default)]
 pub struct EditorSettings {

--- a/editor/moxie/src/main.rs
+++ b/editor/moxie/src/main.rs
@@ -1,11 +1,11 @@
-//! Demonstrates the [`MoxiePlugin`] timeline editor.
+//! The editor binary: [`MoxiePlugin`] over a starting scene.
 //!
-//! A row of cubes runs through four phases - pop in together, rotate
-//! in staggered pairs, race each other, then settle - deliberately
-//! mixing every [`Combinator`] and nesting them inside one another, so
-//! the timeline panel has a real tree to show. The editor docks a
-//! timeline panel at the bottom of the window: use the play/pause
-//! button to control playback and drag on the timeline to scrub.
+//! Until it can open a saved one, that scene is built here. Two rows
+//! of shapes run through five phases - pop in together, rotate in
+//! staggered pairs, race each other, drift apart, then settle - which
+//! between them mix and nest every [`Combinator`], so the timeline
+//! panel has a real tree to show. The shapes hang under a row each,
+//! so the hierarchy panel has one too.
 
 use bevy::asset::uuid::Uuid;
 use bevy::color::palettes;
@@ -25,12 +25,15 @@ use motiongfx_scene::block::{
     ActionCmd, Block, Combinator, Node as AnimNode,
 };
 use motiongfx_scene::refs::FieldRef;
+// Aliased: `Subject` is also what this file calls one of its own
+// animated things.
 use motiongfx_scene::scene::{
-    FieldSeed, Scene as AnimScene, Stage, Subject,
+    FieldSeed, Scene as AnimScene, Stage, Subject as StageSubject,
 };
 use motiongfx_scene::value::ValueColumn;
 
-const CUBE_COUNT: usize = 6;
+/// Shapes in a row, and rows in the scene.
+const PER_ROW: usize = 3;
 
 fn main() {
     App::new()
@@ -48,11 +51,11 @@ fn main() {
         .run();
 }
 
-/// One cube: its subject id and spawn `x`, so later phases can move it
-/// relative to where it started.
-struct Cube {
-    subject: SceneUid,
-    x: f32,
+/// One animated thing: its subject id and where it starts, so a later
+/// phase can move it relative to that.
+struct Subject {
+    id: SceneUid,
+    start: Vec3,
 }
 
 /// The initial value of one animated field, pooled alongside the
@@ -125,16 +128,20 @@ fn move_to(
     })
 }
 
-/// Spawns a row of cubes and an [`EditorScene`] animating them through
-/// four phases, deliberately mixing and nesting every [`Combinator`]:
+/// Spawns two rows of shapes and an [`EditorScene`] animating them
+/// through five phases, deliberately mixing and nesting every
+/// [`Combinator`]:
 ///
-/// 1. **Scale in** (`All`) - every cube pops in at once.
-/// 2. **Paired rotate** (`Flow` of `All` pairs) - cubes rotate two at a
-///    time, each pair staggered after the last.
-/// 3. **Race** (`Any` of an action and a `Chain`) - two cubes chase the
-///    same finish line; the phase ends the instant the faster one
+/// 1. **Scale in** (`All`) - every shape pops in at once.
+/// 2. **Paired rotate** (`Flow` of `All` pairs) - shapes rotate two at
+///    a time, each pair staggered after the last.
+/// 3. **Race** (`Any` of an action and a `Chain`) - two shapes chase
+///    the same finish line; the phase ends the instant the faster one
 ///    does, leaving the slower one mid-flight.
-/// 4. **Finale** (`Chain` of `All` then `Flow`) - every cube settles
+/// 4. **Drift** (`All`) - the rows themselves move apart. Nothing
+///    animates the shapes here: they come along because they hang
+///    under a row, which is what the hierarchy panel is showing.
+/// 5. **Finale** (`Chain` of `All` then `Flow`) - every shape settles
 ///    its scale together, then unwinds its rotation one at a time.
 ///
 /// Built as a [`Scene`] rather than through `motiongfx`'s imperative
@@ -146,57 +153,106 @@ fn spawn_timeline(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let mesh = meshes.add(Cuboid::default());
     let mut values = ValuePool::default();
 
-    let cubes: Vec<Cube> = (0..CUBE_COUNT)
-        .map(|i| {
-            let x = (i as f32) - (CUBE_COUNT as f32 - 1.0) * 0.5;
-            let material =
-                materials.add(StandardMaterial::from_color(
-                    palettes::tailwind::SKY_400,
-                ));
+    // Flat shapes are meshed in the XY plane, so they face the camera
+    // to begin with - and are double sided, or a rotation would turn
+    // them edge-on and then away.
+    let rows = [
+        (
+            "Solids",
+            1.2,
+            palettes::tailwind::SKY_400,
+            [
+                meshes.add(Cuboid::default()),
+                meshes.add(Sphere::new(0.6)),
+                meshes.add(Torus::new(0.22, 0.45)),
+            ],
+        ),
+        (
+            "Flats",
+            -1.2,
+            palettes::tailwind::AMBER_400,
+            [
+                meshes.add(Rectangle::new(1.1, 1.1)),
+                meshes.add(Circle::new(0.62)),
+                meshes.add(RegularPolygon::new(0.68, 6)),
+            ],
+        ),
+    ];
+
+    let mut parents = Vec::new();
+    let mut shapes = Vec::new();
+
+    for (name, y, color, row_meshes) in rows {
+        let origin = Vec3::new(0.0, y, 0.0);
+        let uid = EntityUid::new();
+        let parent = commands
+            .spawn((
+                uid,
+                Name::new(name),
+                Transform::from_translation(origin),
+                Visibility::default(),
+            ))
+            .id();
+        parents.push(Subject {
+            id: SceneUid::Entity(uid),
+            start: origin,
+        });
+
+        let material = materials.add(StandardMaterial {
+            base_color: color.into(),
+            double_sided: true,
+            cull_mode: None,
+            ..default()
+        });
+
+        for (i, mesh) in row_meshes.into_iter().enumerate() {
+            let x = ((i as f32) - (PER_ROW as f32 - 1.0) * 0.5) * 2.0;
+            let start = Vec3::new(x, 0.0, 0.0);
             let uid = EntityUid::new();
+
             commands.spawn((
                 uid,
-                Name::new(format!("Cube {i}")),
-                Mesh3d(mesh.clone()),
-                MeshMaterial3d(material),
-                Transform::from_xyz(x * 1.5, 0.0, 0.0)
+                Name::new(format!("{name} {i}")),
+                Mesh3d(mesh),
+                MeshMaterial3d(material.clone()),
+                Transform::from_translation(start)
                     .with_scale(Vec3::ZERO),
+                ChildOf(parent),
             ));
-            Cube {
-                subject: SceneUid::Entity(uid),
-                x: x * 1.5,
-            }
-        })
-        .collect();
+            shapes.push(Subject {
+                id: SceneUid::Entity(uid),
+                start,
+            });
+        }
+    }
 
-    // Phase 1 - every cube pops in together.
+    // Phase 1 - every shape pops in together.
     let scale_in = Block {
         combinator: Combinator::All,
-        children: cubes
+        children: shapes
             .iter()
-            .map(|cube| {
-                scale_to(cube.subject, &mut values, Vec3::ONE, cs(40))
+            .map(|shape| {
+                scale_to(shape.id, &mut values, Vec3::ONE, cs(40))
             })
             .collect(),
     };
 
-    // Phase 2 - cubes rotate two at a time (an `All` pair), each pair
+    // Phase 2 - shapes rotate two at a time (an `All` pair), each pair
     // staggered after the last (a `Flow` of those pairs).
     let paired_rotate = Block {
         combinator: Combinator::Flow(cs(25)),
-        children: cubes
+        children: shapes
             .chunks(2)
             .map(|pair| {
                 AnimNode::block(Block {
                     combinator: Combinator::All,
                     children: pair
                         .iter()
-                        .map(|cube| {
+                        .map(|shape| {
                             rotate_to(
-                                cube.subject,
+                                shape.id,
                                 &mut values,
                                 Quat::from_rotation_y(
                                     core::f32::consts::PI,
@@ -210,31 +266,31 @@ fn spawn_timeline(
             .collect(),
     };
 
-    // Phase 3 - two cubes race for the same finish line: a lone slow
+    // Phase 3 - two shapes race for the same finish line: a lone slow
     // hop against a `Chain` of two quick hops. `Any` ends the instant
     // the faster one does, so the slow hop is left unfinished.
     let race = Block {
         combinator: Combinator::Any,
         children: vec![
             move_to(
-                cubes[0].subject,
+                shapes[0].id,
                 &mut values,
-                Vec3::new(cubes[0].x, 1.5, 0.0),
+                shapes[0].start + Vec3::Y * 1.5,
                 s(2),
             ),
             AnimNode::block(Block {
                 combinator: Combinator::Chain,
                 children: vec![
                     move_to(
-                        cubes[1].subject,
+                        shapes[1].id,
                         &mut values,
-                        Vec3::new(cubes[1].x, 1.0, 0.0),
+                        shapes[1].start + Vec3::Y,
                         cs(50),
                     ),
                     move_to(
-                        cubes[1].subject,
+                        shapes[1].id,
                         &mut values,
-                        Vec3::new(cubes[1].x, 0.0, 0.0),
+                        shapes[1].start,
                         cs(50),
                     ),
                 ],
@@ -242,18 +298,35 @@ fn spawn_timeline(
         ],
     };
 
-    // Phase 4 - settle every cube's scale together (`All`), then
+    // Phase 4 - the rows themselves move apart. Nothing here names a
+    // shape: they follow because they hang under a row.
+    let drift = Block {
+        combinator: Combinator::All,
+        children: parents
+            .iter()
+            .map(|row| {
+                move_to(
+                    row.id,
+                    &mut values,
+                    row.start + Vec3::Y * row.start.y.signum() * 0.6,
+                    cs(60),
+                )
+            })
+            .collect(),
+    };
+
+    // Phase 5 - settle every shape's scale together (`All`), then
     // unwind their rotation one at a time (`Flow`).
     let finale = Block {
         combinator: Combinator::Chain,
         children: vec![
             AnimNode::block(Block {
                 combinator: Combinator::All,
-                children: cubes
+                children: shapes
                     .iter()
-                    .map(|cube| {
+                    .map(|shape| {
                         scale_to(
-                            cube.subject,
+                            shape.id,
                             &mut values,
                             Vec3::splat(0.7),
                             cs(30),
@@ -263,11 +336,11 @@ fn spawn_timeline(
             }),
             AnimNode::block(Block {
                 combinator: Combinator::Flow(cs(8)),
-                children: cubes
+                children: shapes
                     .iter()
-                    .map(|cube| {
+                    .map(|shape| {
                         rotate_to(
-                            cube.subject,
+                            shape.id,
                             &mut values,
                             Quat::IDENTITY,
                             cs(40),
@@ -282,23 +355,27 @@ fn spawn_timeline(
         AnimNode::block(scale_in),
         AnimNode::block(paired_rotate),
         AnimNode::block(race),
+        AnimNode::block(drift),
         AnimNode::block(finale),
     ]);
 
-    // Every field the animation touches, at what the cubes spawn
+    // Every field the animation touches, at what the shapes spawn
     // holding. Not redundant with that spawn: baking reads off the
-    // world, and an edit recompiles with the cubes wherever the last
-    // run left them.
+    // world, and an edit recompiles with them wherever the last run
+    // left them. A row starts at full scale; a shape pops in from
+    // nothing.
     let stage = Stage {
-        subjects: cubes
+        subjects: shapes
             .iter()
-            .map(|cube| Subject {
-                id: cube.subject,
+            .map(|shape| (shape, Vec3::ZERO))
+            .chain(parents.iter().map(|row| (row, Vec3::ONE)))
+            .map(|(subject, scale)| StageSubject {
+                id: subject.id,
                 fields: vec![
                     seed(
                         &mut values,
                         field_ref(path!(<Transform>::translation)),
-                        Vec3::new(cube.x, 0.0, 0.0),
+                        subject.start,
                     ),
                     seed(
                         &mut values,
@@ -308,7 +385,7 @@ fn spawn_timeline(
                     seed(
                         &mut values,
                         field_ref(path!(<Transform>::scale)),
-                        Vec3::ZERO,
+                        scale,
                     ),
                 ],
             })

--- a/editor/moxie/src/main.rs
+++ b/editor/moxie/src/main.rs
@@ -159,6 +159,7 @@ fn spawn_timeline(
             let uid = EntityUid::new();
             commands.spawn((
                 uid,
+                Name::new(format!("Cube {i}")),
                 Mesh3d(mesh.clone()),
                 MeshMaterial3d(material),
                 Transform::from_xyz(x * 1.5, 0.0, 0.0)

--- a/editor/moxie/src/ui.rs
+++ b/editor/moxie/src/ui.rs
@@ -1,7 +1,3 @@
-//! The editor's dockable windows (viewport, timeline, hierarchy,
-//! action, settings) and the startup system that spawns them against
-//! a dedicated UI camera.
-
 mod action;
 mod hierarchy;
 mod settings;
@@ -103,25 +99,31 @@ fn setup_editor_ui(
 
     register_windows(&mut registry);
 
-    // Layout: viewport (+ its sibling tabs) on top, timeline below.
-    // Leaves are not persistent: emptied areas collapse
-    // automatically.
+    //
+    // The dock layout.
+    //
     let viewport = tree.set_root_leaf(
         DockLeaf::new("viewport", DockAreaStyle::TabBar)
-            .with_windows(vec![
-                "viewport".into(),
-                "hierarchy".into(),
-                "action".into(),
-                "settings".into(),
-            ]),
+            .with_windows(vec!["viewport".into()]),
     );
+
     tree.split(viewport, Edge::Bottom, "timeline".into());
-    let split = tree.root.expect("root split exists");
-    tree.set_fraction(split, 0.7);
+    let vsplit = tree.root.expect("root split exists");
+    tree.set_fraction(vsplit, 0.7);
     if let Some(timeline) = tree.find_leaf_with_window("timeline")
         && let Some(DockNode::Leaf(leaf)) = tree.get_mut(timeline)
     {
         leaf.area_id = "timeline".into();
+    }
+
+    tree.split(viewport, Edge::Right, "action".into());
+    if let Some(hsplit) = tree.parent_of(viewport) {
+        tree.set_fraction(hsplit, 0.8);
+    }
+
+    tree.split(viewport, Edge::Left, "hierarchy".into());
+    if let Some(hsplit) = tree.parent_of(viewport) {
+        tree.set_fraction(hsplit, 0.2);
     }
 
     // The kernel builds the whole tree under this root. `Commands`

--- a/editor/moxie/src/ui.rs
+++ b/editor/moxie/src/ui.rs
@@ -20,13 +20,13 @@ use crate::{
 };
 use bevy_fynix::ElementMutExt;
 use fynix_mock::elem;
-use moxie_ui::MoxieUiPlugin;
 use moxie_ui::elements::{Frame, FrameCursor, Panel};
 use moxie_ui::reactive::{BevyUi, FynixSet, value_changed};
 use moxie_ui::widgets::dock::{
     DockAreaStyle, DockLeaf, DockNode, DockTree,
     DockWindowDescriptor, Edge, WindowRegistry, dock,
 };
+use moxie_ui::{MoxieUiPlugin, palette};
 
 /// Wires feathers theming, the editor UI tree, and the per-frame
 /// timeline/playback/preview systems.
@@ -89,7 +89,7 @@ fn setup_editor_ui(
             Camera2d
             Camera {
                 order: 10,
-                clear_color: Color::BLACK,
+                clear_color: { palette::BASE[0] },
             }
             TrackViewportCamera
         ])

--- a/editor/moxie/src/ui.rs
+++ b/editor/moxie/src/ui.rs
@@ -16,7 +16,7 @@ use bevy::ui::{IsDefaultUiCamera, UiTargetCamera};
 
 use crate::{
     EditorSettings, EditorState, PreviewImage, SelectedAction,
-    playback, scene, view,
+    SelectedEntity, playback, scene, view,
 };
 use bevy_fynix::ElementMutExt;
 use fynix_mock::elem;
@@ -37,6 +37,7 @@ impl Plugin for UiPlugin {
         app.add_plugins(MoxieUiPlugin)
             .init_resource::<EditorState>()
             .init_resource::<SelectedAction>()
+            .init_resource::<SelectedEntity>()
             .add_systems(Startup, setup_editor_ui)
             .add_systems(
                 Update,

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -3,6 +3,10 @@
 //! What counts as one is an [`EntityUid`], which is the id a scene
 //! refers to its subjects by - so the panel lists exactly what the
 //! animation can address, and nothing the editor spawned for itself.
+//!
+//! Each subject watches only its own children, so adding one rebuilds
+//! that branch and not the panel. Depth is the nesting: a subtree
+//! indents what it holds.
 
 use bevy::ecs::query::QueryState;
 use bevy::prelude::*;
@@ -10,101 +14,21 @@ use bevy_motiongfx::scene::id::EntityUid;
 use fynix_mock::composer::Composer;
 use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
-use moxie_ui::elements::{Frame, Label, Panel};
-use moxie_ui::reactive::{BevyHost, BevyUi};
+use moxie_ui::elements::{Frame, Label, LabelCursor, Panel};
+use moxie_ui::reactive::{
+    BevyHost, BevyUi, component_changed_on, value_changed,
+};
 use moxie_ui::theme::EditorTheme;
 
 use super::PANEL_PADDING;
 
-/// Indent per hierarchy level.
+/// How far a subject sets its children in from itself.
 const INDENT: f32 = 12.0;
 
-/// One row: an entity's depth and display name.
-///
-/// Doubles as what builds it. The two would hold the same two fields
-/// either way, and comparing rows is how the panel decides to rebuild
-/// them at all.
-#[derive(Clone, PartialEq)]
-struct Row {
-    depth: usize,
-    name: String,
-}
+/// Between one row and the next, at any depth.
+const ROW_GAP: f32 = 2.0;
 
-impl Composer<BevyHost> for Row {
-    type Element = Frame;
-
-    fn compose(
-        self,
-        ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
-        let color = ui.world.resource::<EditorTheme>().text_primary;
-        let indent = self.depth as f32 * INDENT;
-        let name = self.name;
-
-        ui.elem(elem!(
-            Frame,
-            width = percent(100),
-            align = AlignItems::Center,
-            padding = UiRect::left(px(indent))
-        ))
-        .with(move |ui| {
-            ui.elem(elem!(Label, text = name, color = Some(color)));
-        })
-        .handle()
-    }
-}
-
-/// A scene subject is whatever carries the id one is named by.
-type SceneEntity = With<EntityUid>;
-
-/// The queries the predicate drives.
-struct HierarchyQueries {
-    scene:
-        QueryState<(Entity, Option<&'static Children>), SceneEntity>,
-    names: QueryState<(Option<&'static Name>, &'static EntityUid)>,
-    parents: QueryState<&'static ChildOf>,
-}
-
-impl HierarchyQueries {
-    /// `try_new` rather than `new`: a builder only ever holds
-    /// `&World`. Returns `None` until every component is registered.
-    fn try_new(world: &World) -> Option<Self> {
-        Some(Self {
-            scene: QueryState::try_new(world)?,
-            names: QueryState::try_new(world)?,
-            parents: QueryState::try_new(world)?,
-        })
-    }
-
-    fn update(&mut self, world: &World) {
-        self.scene.update_archetypes(world);
-        self.names.update_archetypes(world);
-        self.parents.update_archetypes(world);
-    }
-
-    /// What the row calls it: its [`Name`] if it was given one, and
-    /// otherwise the head of its id - a whole uuid is unreadable at
-    /// a glance, and its first characters are enough to tell two
-    /// unnamed subjects apart.
-    fn name_of(&self, world: &World, entity: Entity) -> String {
-        /// As many characters of an id as a row shows.
-        const HEAD: usize = 8;
-
-        match self.names.get_manual(world, entity) {
-            Ok((Some(name), _)) => name.as_str().to_string(),
-            Ok((None, uid)) => {
-                uid.to_string().chars().take(HEAD).collect()
-            }
-            Err(_) => "?".to_string(),
-        }
-    }
-
-    fn is_scene(&self, world: &World, entity: Entity) -> bool {
-        self.scene.get_manual(world, entity).is_ok()
-    }
-}
-
-/// The hierarchy panel, as kernel nodes.
+/// Every scene subject, as nested rows.
 pub(super) struct HierarchyPanel;
 
 impl Composer<BevyHost> for HierarchyPanel {
@@ -114,103 +38,181 @@ impl Composer<BevyHost> for HierarchyPanel {
         self,
         ui: &mut BevyUi,
     ) -> ElementHandle<BevyHost, Panel> {
-        // The predicate keeps its queries between polls, because it
-        // runs every flush and building a `QueryState` each time
-        // would not be cheap. The build has no such problem: it only
-        // runs when something actually moved.
-        let mut queries: Option<HierarchyQueries> = None;
-        let mut seen: Option<Vec<Row>> = None;
+        // Roots only - a branch minds itself. The query is kept
+        // because this polls every flush; the build makes its own,
+        // and runs far less often.
+        let mut query = None;
+        let mut seen: Option<Vec<Entity>> = None;
 
         ui.elem(elem!(
             Panel,
             direction = FlexDirection::Column,
-            row_gap = px(2),
+            row_gap = px(ROW_GAP),
             padding = UiRect::all(px(PANEL_PADDING)),
             scrolls = true
         ))
         .watch(
             move |world, _| {
-                let queries = match &mut queries {
-                    Some(queries) => queries,
-                    slot => match HierarchyQueries::try_new(world) {
-                        Some(queries) => slot.insert(queries),
+                let query = match &mut query {
+                    Some(query) => query,
+                    slot => match QueryState::try_new(world) {
+                        Some(query) => slot.insert(query),
                         None => return false,
                     },
                 };
-                let current = collect_rows(world, queries);
+                query.update_archetypes(world);
+
+                let current = roots(world, query);
                 let changed = seen.as_ref() != Some(&current);
                 seen = Some(current);
                 changed
             },
-            build_rows,
+            build_roots,
         )
         .handle()
     }
 }
 
-/// Roots first (a scene entity whose parent isn't itself a scene
-/// entity), then depth-first so children follow their parent.
-fn collect_rows(
-    world: &World,
-    queries: &mut HierarchyQueries,
-) -> Vec<Row> {
-    queries.update(world);
-
-    let mut roots = queries
-        .scene
-        .iter_manual(world)
-        .map(|(entity, _)| entity)
-        .filter(|&entity| {
-            !queries.parents.get_manual(world, entity).is_ok_and(
-                |parent| queries.is_scene(world, parent.parent()),
-            )
-        })
-        .collect::<Vec<_>>();
-    roots.sort_unstable();
-
-    let mut rows = Vec::new();
-    for root in roots {
-        push_subtree(world, queries, root, 0, &mut rows);
-    }
-    rows
-}
-
-/// Depth-first append `entity` and its scene descendants.
-fn push_subtree(
-    world: &World,
-    queries: &HierarchyQueries,
-    entity: Entity,
-    depth: usize,
-    out: &mut Vec<Row>,
-) {
-    let Ok((_, children)) = queries.scene.get_manual(world, entity)
-    else {
-        return;
-    };
-    let name = queries.name_of(world, entity);
-    out.push(Row { depth, name });
-
-    let children = children
-        .map(|children| children.to_vec())
-        .unwrap_or_default();
-    for child in children {
-        push_subtree(world, queries, child, depth + 1, out);
-    }
-}
-
-/// Walks the scene again rather than being handed what the predicate
-/// found. That costs one more walk, but only when something actually
-/// moved - and it keeps the two halves from having to share state.
-fn build_rows(ui: &mut BevyUi) {
-    let rows = {
-        let Some(mut queries) = HierarchyQueries::try_new(ui.world)
-        else {
+fn build_roots(ui: &mut BevyUi) {
+    let roots = {
+        let Some(mut query) = QueryState::try_new(ui.world) else {
             return;
         };
-        collect_rows(ui.world, &mut queries)
+        roots(ui.world, &mut query)
     };
 
-    for row in rows {
-        ui.compose(row);
+    for entity in roots {
+        ui.compose(Subtree { entity });
+    }
+}
+
+/// One subject, and everything under it.
+struct Subtree {
+    entity: Entity,
+}
+
+impl Composer<BevyHost> for Subtree {
+    type Element = Frame;
+
+    fn compose(
+        self,
+        ui: &mut BevyUi,
+    ) -> ElementHandle<BevyHost, Frame> {
+        let entity = self.entity;
+
+        ui.elem(elem!(
+            Frame,
+            width = percent(100),
+            direction = FlexDirection::Column,
+            row_gap = px(ROW_GAP)
+        ))
+        .with(move |ui| {
+            ui.compose(Subject { entity });
+
+            // Indented, watching only whose children they are.
+            ui.elem(elem!(
+                Frame,
+                width = percent(100),
+                direction = FlexDirection::Column,
+                row_gap = px(ROW_GAP),
+                padding = UiRect::new(
+                    px(INDENT),
+                    Val::ZERO,
+                    Val::ZERO,
+                    Val::ZERO
+                )
+            ))
+            .watch(
+                component_changed_on::<Children>(entity),
+                move |ui| {
+                    for child in children_of(ui.world, entity) {
+                        ui.compose(Subtree { entity: child });
+                    }
+                },
+            );
+        })
+        .handle()
+    }
+}
+
+/// One subject's own row.
+struct Subject {
+    entity: Entity,
+}
+
+impl Composer<BevyHost> for Subject {
+    type Element = Label;
+
+    fn compose(
+        self,
+        ui: &mut BevyUi,
+    ) -> ElementHandle<BevyHost, Label> {
+        let entity = self.entity;
+        let color = ui.world.resource::<EditorTheme>().text_primary;
+        let name = name_of(ui.world, entity);
+
+        // Bound, not rebuilt: a rename changes no shape.
+        ui.elem(elem!(Label, text = name, color = Some(color)))
+            .bind(
+                |label| label.text(),
+                value_changed(move |world: &World, _| {
+                    name_of(world, entity)
+                }),
+                move |world, _| name_of(world, entity),
+            )
+            .handle()
+    }
+}
+
+/// Subjects with no subject above them. Sorted, so the panel does not
+/// reshuffle when an archetype does.
+fn roots(
+    world: &World,
+    query: &mut QueryState<Entity, With<EntityUid>>,
+) -> Vec<Entity> {
+    let mut roots: Vec<Entity> = query
+        .iter_manual(world)
+        .filter(|&entity| {
+            !world.get::<ChildOf>(entity).is_some_and(|parent| {
+                is_subject(world, parent.parent())
+            })
+        })
+        .collect();
+
+    roots.sort_unstable();
+    roots
+}
+
+/// The subjects directly under `entity`; anything else it parents is
+/// not the scene's to show.
+fn children_of(world: &World, entity: Entity) -> Vec<Entity> {
+    world
+        .get::<Children>(entity)
+        .map(|children| {
+            children
+                .iter()
+                .filter(|&child| is_subject(world, child))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn is_subject(world: &World, entity: Entity) -> bool {
+    world.get::<EntityUid>(entity).is_some()
+}
+
+/// Its [`Name`], or the head of its id - a whole uuid is unreadable,
+/// and the first characters tell two unnamed subjects apart.
+fn name_of(world: &World, entity: Entity) -> String {
+    /// How much of an id a row shows.
+    const HEAD: usize = 8;
+
+    if let Some(name) = world.get::<Name>(entity) {
+        return name.as_str().to_string();
+    }
+
+    match world.get::<EntityUid>(entity) {
+        Some(uid) => uid.to_string().chars().take(HEAD).collect(),
+        None => "?".to_string(),
     }
 }

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -12,18 +12,14 @@ use bevy::ecs::query::QueryState;
 use bevy::prelude::*;
 use bevy_motiongfx::scene::id::EntityUid;
 use fynix_mock::composer::Composer;
-use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
-use moxie_ui::elements::{Frame, Label, LabelCursor, Panel};
-use moxie_ui::reactive::{
-    BevyHost, BevyUi, component_changed_on, value_changed,
-};
+use fynix_mock::{elem, val};
+use moxie_ui::elements::{Frame, Label, Panel, TintButton};
+use moxie_ui::fold::{Foldable, Toggle};
+use moxie_ui::reactive::{BevyHost, BevyUi, component_changed_on};
 use moxie_ui::theme::EditorTheme;
 
 use super::PANEL_PADDING;
-
-/// How far a subject sets its children in from itself.
-const INDENT: f32 = 12.0;
 
 /// Between one row and the next, at any depth.
 const ROW_GAP: f32 = 2.0;
@@ -99,68 +95,46 @@ impl Composer<BevyHost> for Subtree {
         ui: &mut BevyUi,
     ) -> ElementHandle<BevyHost, Frame> {
         let entity = self.entity;
-
-        ui.elem(elem!(
-            Frame,
-            width = percent(100),
-            direction = FlexDirection::Column,
-            row_gap = px(ROW_GAP)
-        ))
-        .with(move |ui| {
-            ui.compose(Subject { entity });
-
-            // Indented, watching only whose children they are.
-            ui.elem(elem!(
-                Frame,
-                width = percent(100),
-                direction = FlexDirection::Column,
-                row_gap = px(ROW_GAP),
-                padding = UiRect::new(
-                    px(INDENT),
-                    Val::ZERO,
-                    Val::ZERO,
-                    Val::ZERO
-                )
-            ))
-            .watch(
-                component_changed_on::<Children>(entity),
-                move |ui| {
-                    for child in children_of(ui.world, entity) {
-                        ui.compose(Subtree { entity: child });
-                    }
-                },
-            );
-        })
-        .handle()
-    }
-}
-
-/// One subject's own row.
-struct Subject {
-    entity: Entity,
-}
-
-impl Composer<BevyHost> for Subject {
-    type Element = Label;
-
-    fn compose(
-        self,
-        ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Label> {
-        let entity = self.entity;
-        let color = ui.world.resource::<EditorTheme>().text_primary;
+        let primary = ui.world.resource::<EditorTheme>().text_primary;
         let name = name_of(ui.world, entity);
 
-        // Bound, not rebuilt: a rename changes no shape.
-        ui.elem(elem!(Label, text = name, color = Some(color)))
-            .bind(
-                |label| label.text(),
-                value_changed(move |world: &World, _| {
-                    name_of(world, entity)
-                }),
-                move |world, _| name_of(world, entity),
-            )
-            .handle()
+        ui.compose(Foldable {
+            header: elem!(
+                !TintButton,
+                width = percent(100),
+                height = px(18),
+                justify = JustifyContent::FlexStart,
+                padding = UiRect::axes(px(4), Val::ZERO),
+                radius = px(3),
+                label = val!(
+                    Label,
+                    text = name,
+                    wrap = false,
+                    color = Some(primary)
+                )
+            ),
+            // The row is the subject's, to select; only the chevron
+            // beside it folds.
+            toggle: Toggle::Chevron,
+            enabled: has_children(ui.world, entity),
+            body: move |ui: &mut BevyUi| {
+                ui.elem(elem!(
+                    Frame,
+                    width = percent(100),
+                    direction = FlexDirection::Column,
+                    row_gap = px(ROW_GAP)
+                ))
+                .watch(
+                    component_changed_on::<Children>(entity),
+                    move |ui| {
+                        for child in children_of(ui.world, entity) {
+                            ui.compose(Subtree { entity: child });
+                        }
+                    },
+                );
+            },
+        })
+        .handle()
     }
 }
 
@@ -195,6 +169,14 @@ fn children_of(world: &World, entity: Entity) -> Vec<Entity> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Whether `entity` has any subject under it, without collecting
+/// them - a row only needs to know that there is something to fold.
+fn has_children(world: &World, entity: Entity) -> bool {
+    world.get::<Children>(entity).is_some_and(|children| {
+        children.iter().any(|child| is_subject(world, child))
+    })
 }
 
 fn is_subject(world: &World, entity: Entity) -> bool {

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -1,13 +1,14 @@
-//! Scene hierarchy browser: an indented list of the scene's entities.
+//! Scene hierarchy browser: an indented list of the scene's subjects.
 //!
-//! Only *scene* entities are listed (anything with a [`Transform`] that
-//! isn't editor UI), so the panel shows the composition's objects, not
-//! the editor chrome.
+//! What counts as one is an [`EntityUid`], which is the id a scene
+//! refers to its subjects by - so the panel lists exactly what the
+//! animation can address, and nothing the editor spawned for itself.
 
 use std::sync::{Arc, Mutex};
 
 use bevy::ecs::query::QueryState;
 use bevy::prelude::*;
+use bevy_motiongfx::scene::id::EntityUid;
 use fynix_mock::composer::Composer;
 use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
@@ -15,7 +16,7 @@ use moxie_ui::elements::{Frame, Label, Panel};
 use moxie_ui::reactive::{BevyHost, BevyUi};
 use moxie_ui::theme::EditorTheme;
 
-use super::{PANEL_PADDING, TrackViewportCamera};
+use super::PANEL_PADDING;
 
 /// Indent per hierarchy level.
 const INDENT: f32 = 12.0;
@@ -27,15 +28,14 @@ struct Row {
     name: String,
 }
 
-/// Scene entities: transform-bearing and not editor UI.
-type SceneEntity =
-    (With<Transform>, Without<Node>, Without<TrackViewportCamera>);
+/// A scene subject is whatever carries the id one is named by.
+type SceneEntity = With<EntityUid>;
 
 /// The queries the predicate drives.
 struct HierarchyQueries {
     scene:
         QueryState<(Entity, Option<&'static Children>), SceneEntity>,
-    names: QueryState<&'static Name>,
+    names: QueryState<(Option<&'static Name>, &'static EntityUid)>,
     parents: QueryState<&'static ChildOf>,
 }
 
@@ -54,6 +54,23 @@ impl HierarchyQueries {
         self.scene.update_archetypes(world);
         self.names.update_archetypes(world);
         self.parents.update_archetypes(world);
+    }
+
+    /// What the row calls it: its [`Name`] if it was given one, and
+    /// otherwise the head of its id - a whole uuid is unreadable at
+    /// a glance, and its first characters are enough to tell two
+    /// unnamed subjects apart.
+    fn name_of(&self, world: &World, entity: Entity) -> String {
+        /// As many characters of an id as a row shows.
+        const HEAD: usize = 8;
+
+        match self.names.get_manual(world, entity) {
+            Ok((Some(name), _)) => name.as_str().to_string(),
+            Ok((None, uid)) => {
+                uid.to_string().chars().take(HEAD).collect()
+            }
+            Err(_) => "?".to_string(),
+        }
     }
 
     fn is_scene(&self, world: &World, entity: Entity) -> bool {
@@ -148,11 +165,7 @@ fn push_subtree(
     else {
         return;
     };
-    let name = queries
-        .names
-        .get_manual(world, entity)
-        .map(|name| name.as_str().to_string())
-        .unwrap_or_else(|_| format!("Entity {}", entity.index()));
+    let name = queries.name_of(world, entity);
     out.push(Row { depth, name });
 
     let children = children

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -4,8 +4,6 @@
 //! refers to its subjects by - so the panel lists exactly what the
 //! animation can address, and nothing the editor spawned for itself.
 
-use std::sync::{Arc, Mutex};
-
 use bevy::ecs::query::QueryState;
 use bevy::prelude::*;
 use bevy_motiongfx::scene::id::EntityUid;
@@ -22,10 +20,38 @@ use super::PANEL_PADDING;
 const INDENT: f32 = 12.0;
 
 /// One row: an entity's depth and display name.
+///
+/// Doubles as what builds it. The two would hold the same two fields
+/// either way, and comparing rows is how the panel decides to rebuild
+/// them at all.
 #[derive(Clone, PartialEq)]
 struct Row {
     depth: usize,
     name: String,
+}
+
+impl Composer<BevyHost> for Row {
+    type Element = Frame;
+
+    fn compose(
+        self,
+        ui: &mut BevyUi,
+    ) -> ElementHandle<BevyHost, Frame> {
+        let color = ui.world.resource::<EditorTheme>().text_primary;
+        let indent = self.depth as f32 * INDENT;
+        let name = self.name;
+
+        ui.elem(elem!(
+            Frame,
+            width = percent(100),
+            align = AlignItems::Center,
+            padding = UiRect::left(px(indent))
+        ))
+        .with(move |ui| {
+            ui.elem(elem!(Label, text = name, color = Some(color)));
+        })
+        .handle()
+    }
 }
 
 /// A scene subject is whatever carries the id one is named by.
@@ -88,12 +114,12 @@ impl Composer<BevyHost> for HierarchyPanel {
         self,
         ui: &mut BevyUi,
     ) -> ElementHandle<BevyHost, Panel> {
-        // The rows the predicate found, handed to the build that
-        // follows it: collecting them twice would walk the whole
-        // scene twice per change.
-        let rows: Arc<Mutex<Vec<Row>>> = Arc::default();
-        let seen = rows.clone();
+        // The predicate keeps its queries between polls, because it
+        // runs every flush and building a `QueryState` each time
+        // would not be cheap. The build has no such problem: it only
+        // runs when something actually moved.
         let mut queries: Option<HierarchyQueries> = None;
+        let mut seen: Option<Vec<Row>> = None;
 
         ui.elem(elem!(
             Panel,
@@ -112,15 +138,11 @@ impl Composer<BevyHost> for HierarchyPanel {
                     },
                 };
                 let current = collect_rows(world, queries);
-                let mut seen = seen.lock().unwrap();
-                let changed = *seen != current;
-                *seen = current;
+                let changed = seen.as_ref() != Some(&current);
+                seen = Some(current);
                 changed
             },
-            move |ui| {
-                let rows = rows.lock().unwrap();
-                build_rows(ui, &rows);
-            },
+            build_rows,
         )
         .handle()
     }
@@ -176,24 +198,19 @@ fn push_subtree(
     }
 }
 
-fn build_rows(ui: &mut BevyUi, rows: &[Row]) {
-    let text_color = ui.world.resource::<EditorTheme>().text_primary;
+/// Walks the scene again rather than being handed what the predicate
+/// found. That costs one more walk, but only when something actually
+/// moved - and it keeps the two halves from having to share state.
+fn build_rows(ui: &mut BevyUi) {
+    let rows = {
+        let Some(mut queries) = HierarchyQueries::try_new(ui.world)
+        else {
+            return;
+        };
+        collect_rows(ui.world, &mut queries)
+    };
 
     for row in rows {
-        let indent = row.depth as f32 * INDENT;
-        let name = row.name.clone();
-        ui.elem(elem!(
-            Frame,
-            width = percent(100),
-            align = AlignItems::Center,
-            padding = UiRect::left(px(indent))
-        ))
-        .with(move |ui| {
-            ui.elem(elem!(
-                Label,
-                text = name,
-                color = Some(text_color)
-            ));
-        });
+        ui.compose(row);
     }
 }

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -10,16 +10,21 @@
 
 use bevy::ecs::query::QueryState;
 use bevy::prelude::*;
+use bevy::ui_widgets::Activate;
+use bevy_fynix::ElementMutExt;
 use bevy_motiongfx::scene::id::EntityUid;
 use fynix_mock::composer::Composer;
-use fynix_mock::ui::ElementHandle;
+use fynix_mock::ui::{ElementHandle, ElementMut};
 use fynix_mock::{elem, val};
-use moxie_ui::elements::{Frame, Label, Panel, TintButton};
+use moxie_ui::elements::{
+    ButtonElem, ButtonElemCursor, Frame, Label, Panel, TintButton,
+};
 use moxie_ui::fold::{Foldable, Toggle};
 use moxie_ui::reactive::{BevyHost, BevyUi, component_changed_on};
 use moxie_ui::theme::EditorTheme;
 
 use super::PANEL_PADDING;
+use crate::SelectedEntity;
 
 /// Between one row and the next, at any depth.
 const ROW_GAP: f32 = 2.0;
@@ -95,7 +100,7 @@ impl Composer<BevyHost> for Subtree {
         ui: &mut BevyUi,
     ) -> ElementHandle<BevyHost, Frame> {
         let entity = self.entity;
-        let primary = ui.world.resource::<EditorTheme>().text_primary;
+        let theme = ui.world.resource::<EditorTheme>().clone();
         let name = name_of(ui.world, entity);
 
         ui.compose(Foldable {
@@ -110,13 +115,42 @@ impl Composer<BevyHost> for Subtree {
                     Label,
                     text = name,
                     wrap = false,
-                    color = Some(primary)
+                    color = Some(theme.text_primary)
                 )
             ),
             // The row is the subject's, to select; only the chevron
             // beside it folds.
             toggle: Toggle::Chevron,
             enabled: has_children(ui.world, entity),
+            on_header: move |header: ElementMut<
+                '_,
+                '_,
+                BevyHost,
+                ButtonElem,
+            >| {
+                header
+                    .observe(
+                        move |_: On<Activate>,
+                              mut selected: ResMut<
+                            SelectedEntity,
+                        >| {
+                            selected.0 = Some(entity);
+                        },
+                    )
+                    .bind(
+                        |button| button.fill(),
+                        selection_changed(entity),
+                        move |world, _| {
+                            if world.resource::<SelectedEntity>().0
+                                == Some(entity)
+                            {
+                                theme.accent.with_alpha(0.18)
+                            } else {
+                                Color::NONE
+                            }
+                        },
+                    );
+            },
             body: move |ui: &mut BevyUi| {
                 ui.elem(elem!(
                     Frame,
@@ -177,6 +211,20 @@ fn has_children(world: &World, entity: Entity) -> bool {
     world.get::<Children>(entity).is_some_and(|children| {
         children.iter().any(|child| is_subject(world, child))
     })
+}
+
+/// Fires when `entity` gains or loses the hierarchy's selection.
+fn selection_changed(
+    entity: Entity,
+) -> impl FnMut(&World, Entity) -> bool {
+    let mut seen: Option<bool> = None;
+    move |world, _| {
+        let current =
+            world.resource::<SelectedEntity>().0 == Some(entity);
+        let fired = seen != Some(current);
+        seen = Some(current);
+        fired
+    }
 }
 
 fn is_subject(world: &World, entity: Entity) -> bool {

--- a/editor/moxie_ui/src/elements/dock.rs
+++ b/editor/moxie_ui/src/elements/dock.rs
@@ -14,8 +14,8 @@ use fynix_mock::lenz::Lenz;
 
 use crate::widgets::dock::{
     ActiveDockWindow, DockArea, DockAreaStyle, DockTabContent,
-    DockTreeHost, DockWindow, NodeBinding, NodeId, Panel, PanelGroup,
-    PanelHandle, TabId,
+    DockTreeHost, DockWindow, HANDLE_SIZE, NodeBinding, NodeId,
+    Panel, PanelGroup, PanelHandle, TabId,
 };
 
 /// Column that fills its parent, which most of the dock's nodes are.
@@ -115,6 +115,8 @@ impl ElementVisual<BevyHost> for SplitGroup {
 pub struct SplitHandle {
     #[default(NodeId(0))]
     pub node: NodeId,
+    #[default(::Row)]
+    pub axis: FlexDirection,
     /// Hidden when either side of the split has collapsed: there is
     /// nothing left to drag between.
     #[default(true)]
@@ -122,10 +124,23 @@ pub struct SplitHandle {
 }
 
 impl SplitHandle {
+    /// Full-sized hit area, pulled back onto the seam by a matching
+    /// negative margin so the panels read as touching.
     fn node(&self) -> Node {
+        let pull = px(-HANDLE_SIZE / 2.0);
+        let margin = match self.axis {
+            FlexDirection::Row | FlexDirection::RowReverse => {
+                UiRect::horizontal(pull)
+            }
+            FlexDirection::Column | FlexDirection::ColumnReverse => {
+                UiRect::vertical(pull)
+            }
+        };
+
         Node {
-            min_width: px(3),
-            min_height: px(3),
+            min_width: px(HANDLE_SIZE),
+            min_height: px(HANDLE_SIZE),
+            margin,
             display: display(self.visible),
             ..default()
         }
@@ -154,7 +169,7 @@ impl ElementVisual<BevyHost> for SplitHandle {
             SplitHandleField::Node => {
                 entity.insert(NodeBinding(self.node));
             }
-            SplitHandleField::Visible => {
+            SplitHandleField::Axis | SplitHandleField::Visible => {
                 entity.insert(self.node());
             }
         }

--- a/editor/moxie_ui/src/elements/dock.rs
+++ b/editor/moxie_ui/src/elements/dock.rs
@@ -12,6 +12,7 @@ use fynix_mock::OverrideDefault;
 use fynix_mock::element::{Element, ElementVisual};
 use fynix_mock::lenz::Lenz;
 
+use super::Frame;
 use crate::widgets::dock::{
     ActiveDockWindow, DockArea, DockAreaStyle, DockTabContent,
     DockTreeHost, DockWindow, HANDLE_SIZE, NodeBinding, NodeId,
@@ -110,7 +111,9 @@ impl ElementVisual<BevyHost> for SplitGroup {
     }
 }
 
-/// What a split is dragged by.
+/// What a split is dragged by: a full-sized hit area holding a
+/// slim, always-visible [`line`](Self::line) and a wider
+/// [`bar`](Self::bar) that only shows on hover.
 #[derive(Element, OverrideDefault, Lenz)]
 pub struct SplitHandle {
     #[default(NodeId(0))]
@@ -121,11 +124,21 @@ pub struct SplitHandle {
     /// nothing left to drag between.
     #[default(true)]
     pub visible: bool,
+    /// Marks the seam at rest. Never interactive, and never lit -
+    /// [`handle_line`] gives it a fixed color.
+    #[elem]
+    pub line: Frame,
+    /// Half the hit area and centred in it, so the seam reads flush
+    /// until the cursor finds it. `lit` on this is what actually
+    /// colors the handle.
+    #[elem]
+    pub bar: Frame,
 }
 
 impl SplitHandle {
     /// Full-sized hit area, pulled back onto the seam by a matching
-    /// negative margin so the panels read as touching.
+    /// negative margin so the panels read as touching. Centers
+    /// [`bar`](Self::bar), which carries its own thinner size.
     fn node(&self) -> Node {
         let pull = px(-HANDLE_SIZE / 2.0);
         let margin = match self.axis {
@@ -141,8 +154,60 @@ impl SplitHandle {
             min_width: px(HANDLE_SIZE),
             min_height: px(HANDLE_SIZE),
             margin,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
             display: display(self.visible),
             ..default()
+        }
+    }
+}
+
+/// The bar's own size: thin on the split's axis, full-length across
+/// it.
+pub fn handle_bar(axis: FlexDirection) -> Frame {
+    let thin = px(HANDLE_SIZE / 2.0);
+    match axis {
+        FlexDirection::Row | FlexDirection::RowReverse => Frame {
+            width: thin,
+            height: percent(100),
+            ..default()
+        },
+        FlexDirection::Column | FlexDirection::ColumnReverse => {
+            Frame {
+                width: percent(100),
+                height: thin,
+                ..default()
+            }
+        }
+    }
+}
+
+/// One pixel, centered in the hit area by explicit inset rather than
+/// flex alignment - it sits outside the flow so `bar` can still
+/// center itself normally.
+pub fn handle_line(axis: FlexDirection, color: Color) -> Frame {
+    const LINE: f32 = 1.0;
+    let offset = px((HANDLE_SIZE - LINE) / 2.0);
+    let base = Frame {
+        position: PositionType::Absolute,
+        background: color,
+        ..default()
+    };
+
+    match axis {
+        FlexDirection::Row | FlexDirection::RowReverse => Frame {
+            width: px(LINE),
+            height: percent(100),
+            inset: UiRect::horizontal(offset),
+            ..base
+        },
+        FlexDirection::Column | FlexDirection::ColumnReverse => {
+            Frame {
+                width: percent(100),
+                height: px(LINE),
+                inset: UiRect::vertical(offset),
+                ..base
+            }
         }
     }
 }
@@ -153,7 +218,9 @@ impl ElementVisual<BevyHost> for SplitHandle {
             PanelHandle,
             NodeBinding(self.node),
             self.node(),
-            BackgroundColor(Color::NONE),
+            // Overlaps both panels by design; without this the
+            // second one, painted after it, would win the pointer.
+            ZIndex(1),
         ));
     }
 

--- a/editor/moxie_ui/src/elements/inspector.rs
+++ b/editor/moxie_ui/src/elements/inspector.rs
@@ -119,14 +119,7 @@ impl Composer<BevyHost> for EntityInspector {
 
         column(ui, px(8), components_changed(entity), move |ui| {
             for (component, name) in inspectable(ui.world, entity) {
-                // Headed by the whole component, at the empty path,
-                // which the walk only ever hands groups *inside* -
-                // so a component's fold and its groups' never
-                // collide.
-                let field = Field::new(entity, component);
-
                 ui.compose(Section {
-                    field,
                     name: name.to_string(),
                     body: move |ui: &mut BevyUi| {
                         ui.compose(ComponentInspector {

--- a/editor/moxie_ui/src/fold.rs
+++ b/editor/moxie_ui/src/fold.rs
@@ -70,7 +70,11 @@ pub enum Toggle {
 /// All this owns is the mechanism: the click that toggles, the
 /// chevron that turns, the body that goes, and the rail marking how
 /// deep that body sits.
-pub struct Foldable<S, B> {
+pub struct Foldable<
+    S,
+    B,
+    H = for<'u, 'a> fn(ElementMut<'u, 'a, BevyHost, ButtonElem>),
+> {
     /// Anything built on a [`ButtonElem`]. Under [`Toggle::Header`]
     /// its icon slot is the chevron, so it has to carry one.
     pub header: S,
@@ -79,13 +83,18 @@ pub struct Foldable<S, B> {
     /// it neither turns nor toggles, and its chevron is left out
     /// rather than dimmed, since a hover would light it up again.
     pub enabled: bool,
+    /// Run on the header once it's built, after folding is wired to
+    /// it under [`Toggle::Header`] - so a header that also means
+    /// something of its own, like selecting a row, can still say so.
+    pub on_header: H,
     pub body: B,
 }
 
-impl<S, B> Composer<BevyHost> for Foldable<S, B>
+impl<S, B, H> Composer<BevyHost> for Foldable<S, B, H>
 where
     S: StyledElem<Host = BevyHost, Element = ButtonElem>,
     B: FnOnce(&mut BevyUi),
+    H: for<'u, 'a> FnOnce(ElementMut<'u, 'a, BevyHost, ButtonElem>),
 {
     type Element = Frame;
 
@@ -97,6 +106,7 @@ where
             header,
             toggle,
             enabled,
+            on_header,
             body,
         } = self;
         let theme = ui.world.resource::<EditorTheme>().clone();
@@ -121,32 +131,31 @@ where
             ))
             .with(move |ui| {
                 if chevron {
-                    folds(
-                        ui.elem(elem!(
-                            !GhostButton,
-                            width = px(TOGGLE),
-                            height = px(TOGGLE),
-                            radius = px(3),
-                            icon = val!(
-                                Icon,
-                                image = icons::CHEVRON,
-                                size = px(8),
-                                color = theme.text_muted,
-                                rotation = CHEVRON_OPEN
-                            )
-                        )),
-                        node,
-                    );
+                    let toggle = ui.elem(elem!(
+                        !GhostButton,
+                        width = px(TOGGLE),
+                        height = px(TOGGLE),
+                        radius = px(3),
+                        icon = val!(
+                            Icon,
+                            image = icons::CHEVRON,
+                            size = px(8),
+                            color = theme.text_muted,
+                            rotation = CHEVRON_OPEN
+                        )
+                    ));
+                    folds(toggle, node);
                 }
 
                 // Takes the rest of the row, so a header asking for
                 // its full width gets what is left beside a chevron.
                 ui.elem(elem!(Frame, flex_grow = 1.0f32)).with(
                     move |ui| {
-                        let header = ui.elem(header);
+                        let mut header = ui.elem(header);
                         if enabled && !chevron {
-                            folds(header, node);
+                            header = folds(header, node);
                         }
+                        on_header(header);
                     },
                 );
             });
@@ -205,10 +214,10 @@ where
 
 /// Makes `button` the one that folds `node`, turning its chevron with
 /// the state.
-fn folds(
-    button: ElementMut<'_, '_, BevyHost, ButtonElem>,
+fn folds<'u, 'a>(
+    button: ElementMut<'u, 'a, BevyHost, ButtonElem>,
     node: Entity,
-) {
+) -> ElementMut<'u, 'a, BevyHost, ButtonElem> {
     button
         .observe(move |_: On<Activate>, mut commands: Commands| {
             commands.queue(move |world: &mut World| {
@@ -225,5 +234,5 @@ fn folds(
                     CHEVRON_OPEN
                 }
             },
-        );
+        )
 }

--- a/editor/moxie_ui/src/fold.rs
+++ b/editor/moxie_ui/src/fold.rs
@@ -1,0 +1,229 @@
+//! Folding something away.
+//!
+//! The state is a marker on the node that heads the fold, so it is
+//! read and written right where it is used and nothing has to name
+//! it. It goes when that node does: rebuilding what surrounds a fold
+//! opens it again.
+
+use bevy::prelude::*;
+use bevy::ui_widgets::Activate;
+use bevy_fynix::ElementMutExt;
+use fynix_mock::composer::Composer;
+use fynix_mock::style::StyledElem;
+use fynix_mock::ui::{ElementHandle, ElementMut};
+use fynix_mock::{elem, val};
+
+use crate::elements::{
+    ButtonElem, ButtonElemCursor, Frame, FrameCursor, GhostButton,
+    Icon, IconCursor,
+};
+use crate::icons;
+use crate::reactive::{BevyHost, BevyUi, component_changed_on};
+use crate::theme::EditorTheme;
+
+/// The chevron's rotation, clockwise from the asset's resting
+/// up-pointing orientation: right when shut, down when open.
+pub const CHEVRON_SHUT: f32 = 90.0;
+pub const CHEVRON_OPEN: f32 = 180.0;
+
+/// A chevron of its own, sized to sit beside a row.
+const TOGGLE: f32 = 14.0;
+
+/// How far the rail sets the body in from the header.
+const INDENT: f32 = 9.0;
+
+/// On a [`Foldable`]'s own node while its body is hidden.
+#[derive(Component)]
+pub struct Folded;
+
+pub fn is_folded(world: &World, node: Entity) -> bool {
+    world.get::<Folded>(node).is_some()
+}
+
+pub fn toggle_folded(world: &mut World, node: Entity) {
+    let Ok(mut node) = world.get_entity_mut(node) else {
+        return;
+    };
+
+    if node.contains::<Folded>() {
+        node.remove::<Folded>();
+    } else {
+        node.insert(Folded);
+    }
+}
+
+/// What a click has to land on to fold.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Toggle {
+    /// The header itself, turning the chevron already in its icon
+    /// slot - for a header that has nothing else to mean.
+    Header,
+    /// A chevron of its own beside the header, leaving the header
+    /// free to mean something else, like selecting the row.
+    Chevron,
+}
+
+/// A header that folds away what is built under it.
+///
+/// The header is passed in whole rather than described, so a section
+/// and a tree row can look nothing alike and still fold the same way.
+/// All this owns is the mechanism: the click that toggles, the
+/// chevron that turns, the body that goes, and the rail marking how
+/// deep that body sits.
+pub struct Foldable<S, B> {
+    /// Anything built on a [`ButtonElem`]. Under [`Toggle::Header`]
+    /// its icon slot is the chevron, so it has to carry one.
+    pub header: S,
+    pub toggle: Toggle,
+    /// Whether there is anything to fold. A header with nothing under
+    /// it neither turns nor toggles, and its chevron is left out
+    /// rather than dimmed, since a hover would light it up again.
+    pub enabled: bool,
+    pub body: B,
+}
+
+impl<S, B> Composer<BevyHost> for Foldable<S, B>
+where
+    S: StyledElem<Host = BevyHost, Element = ButtonElem>,
+    B: FnOnce(&mut BevyUi),
+{
+    type Element = Frame;
+
+    fn compose(
+        self,
+        ui: &mut BevyUi,
+    ) -> ElementHandle<BevyHost, Frame> {
+        let Self {
+            header,
+            toggle,
+            enabled,
+            body,
+        } = self;
+        let theme = ui.world.resource::<EditorTheme>().clone();
+        let chevron = enabled && toggle == Toggle::Chevron;
+
+        let root = ui.elem(elem!(
+            Frame,
+            width = percent(100),
+            direction = FlexDirection::Column,
+            row_gap = px(2)
+        ));
+        // Every part reads the fold off this one node, so the chevron
+        // can turn and the body can go.
+        let node = root.id();
+
+        root.with(move |ui| {
+            ui.elem(elem!(
+                Frame,
+                width = percent(100),
+                direction = FlexDirection::Row,
+                align = AlignItems::Center
+            ))
+            .with(move |ui| {
+                if chevron {
+                    folds(
+                        ui.elem(elem!(
+                            !GhostButton,
+                            width = px(TOGGLE),
+                            height = px(TOGGLE),
+                            radius = px(3),
+                            icon = val!(
+                                Icon,
+                                image = icons::CHEVRON,
+                                size = px(8),
+                                color = theme.text_muted,
+                                rotation = CHEVRON_OPEN
+                            )
+                        )),
+                        node,
+                    );
+                }
+
+                // Takes the rest of the row, so a header asking for
+                // its full width gets what is left beside a chevron.
+                ui.elem(elem!(Frame, flex_grow = 1.0f32)).with(
+                    move |ui| {
+                        let header = ui.elem(header);
+                        if enabled && !chevron {
+                            folds(header, node);
+                        }
+                    },
+                );
+            });
+
+            // Set in under the chevron's own middle, so the rail runs
+            // down through it.
+            ui.elem(elem!(
+                Frame,
+                width = percent(100),
+                direction = FlexDirection::Row,
+                align = AlignItems::Stretch,
+                padding = UiRect::new(
+                    px(TOGGLE / 2.0),
+                    Val::ZERO,
+                    Val::ZERO,
+                    Val::ZERO
+                )
+            ))
+            .bind(
+                |frame| frame.display(),
+                component_changed_on::<Folded>(node),
+                move |world, _| {
+                    if is_folded(world, node) {
+                        Display::None
+                    } else {
+                        Display::Flex
+                    }
+                },
+            )
+            .with(move |ui| {
+                // A rail beside the body, the way a tree view marks
+                // how deep a nested branch sits - stretched to the
+                // block's height rather than sized by hand.
+                ui.elem(elem!(
+                    Frame,
+                    width = px(1),
+                    background = theme.palette.base[2]
+                ));
+                ui.elem(elem!(
+                    Frame,
+                    direction = FlexDirection::Column,
+                    flex_grow = 1.0f32,
+                    padding = UiRect::new(
+                        px(INDENT),
+                        Val::ZERO,
+                        Val::ZERO,
+                        Val::ZERO
+                    )
+                ))
+                .with(body);
+            });
+        })
+        .handle()
+    }
+}
+
+/// Makes `button` the one that folds `node`, turning its chevron with
+/// the state.
+fn folds(
+    button: ElementMut<'_, '_, BevyHost, ButtonElem>,
+    node: Entity,
+) {
+    button
+        .observe(move |_: On<Activate>, mut commands: Commands| {
+            commands.queue(move |world: &mut World| {
+                toggle_folded(world, node);
+            });
+        })
+        .bind(
+            |button| button.icon().rotation(),
+            component_changed_on::<Folded>(node),
+            move |world, _| {
+                if is_folded(world, node) {
+                    CHEVRON_SHUT
+                } else {
+                    CHEVRON_OPEN
+                }
+            },
+        );
+}

--- a/editor/moxie_ui/src/inspector.rs
+++ b/editor/moxie_ui/src/inspector.rs
@@ -129,7 +129,11 @@ pub fn inspect_value(ui: &mut BevyUi, source: &dyn Source) {
     if let Some(drawer) = drawer {
         drawer.build(source, ui);
     } else if let Some(variants) = enums::variants(&*value) {
-        let pick = enums::all_unit(&*value);
+        let pick = {
+            let registry =
+                ui.world.resource::<AppTypeRegistry>().read();
+            enums::constructible(&*value, &registry)
+        };
         ui.compose(enums::VariantPicker {
             source,
             variants,

--- a/editor/moxie_ui/src/inspector/enums.rs
+++ b/editor/moxie_ui/src/inspector/enums.rs
@@ -6,16 +6,24 @@
 //! is also what lets it serve enums from crates the inspector cannot
 //! name.
 //!
-//! Only unit variants can be picked. Switching into one that carries
-//! data would mean inventing that data, so an enum that has any is
-//! shown at whichever variant it is already on, with that variant's
-//! fields walked underneath like a struct's.
+//! Switching into a variant that carries data means inventing that
+//! data: a unit variant needs none, and a variant with fields is
+//! constructible when every one of its field types has a registered
+//! [`ReflectDefault`]. An enum with any variant that isn't - some
+//! field type nothing derives `Default` for - is shown read-only, at
+//! whichever variant it is already on, with that variant's fields
+//! walked underneath like a struct's.
 
 use bevy::prelude::*;
 use bevy::reflect::enums::{
-    DynamicEnum, DynamicVariant, VariantType,
+    DynamicEnum, DynamicVariant, VariantInfo,
 };
-use bevy::reflect::{PartialReflect, ReflectRef, TypeInfo};
+use bevy::reflect::std_traits::ReflectDefault;
+use bevy::reflect::structs::DynamicStruct;
+use bevy::reflect::tuple::DynamicTuple;
+use bevy::reflect::{
+    PartialReflect, ReflectRef, TypeInfo, TypeRegistry,
+};
 use bevy::ui_widgets::Activate;
 
 use bevy_fynix::ElementMutExt;
@@ -54,17 +62,83 @@ pub(super) fn variants(
     Some(info.variant_names().iter().map(|n| n.to_string()).collect())
 }
 
-/// Whether every variant is a unit one, and so free to pick.
-pub(super) fn all_unit(value: &dyn PartialReflect) -> bool {
+/// Whether every variant of `value`'s type can be switched into.
+pub(super) fn constructible(
+    value: &dyn PartialReflect,
+    registry: &TypeRegistry,
+) -> bool {
     let Some(TypeInfo::Enum(info)) =
         value.get_represented_type_info()
     else {
         return false;
     };
 
-    (0..info.variant_len()).all(|index| {
-        info.variant_at(index)
-            .is_some_and(|v| v.variant_type() == VariantType::Unit)
+    info.iter().all(|variant| defaultable(variant, registry))
+}
+
+/// A unit variant needs nothing; a variant with fields needs every
+/// field's type to carry a [`ReflectDefault`].
+fn defaultable(
+    variant: &VariantInfo,
+    registry: &TypeRegistry,
+) -> bool {
+    match variant {
+        VariantInfo::Unit(_) => true,
+        VariantInfo::Struct(info) => info
+            .iter()
+            .all(|field| has_default(field.type_id(), registry)),
+        VariantInfo::Tuple(info) => info
+            .iter()
+            .all(|field| has_default(field.type_id(), registry)),
+    }
+}
+
+fn has_default(
+    type_id: core::any::TypeId,
+    registry: &TypeRegistry,
+) -> bool {
+    registry.get_type_data::<ReflectDefault>(type_id).is_some()
+}
+
+/// `name` as a [`DynamicVariant`] of `value`'s type, its fields (if
+/// any) filled from their own [`ReflectDefault`]. `None` if the
+/// variant isn't constructible - a caller only reaches this from a
+/// picker [`constructible`] already gated, so that should not happen.
+fn constructed(
+    value: &dyn PartialReflect,
+    registry: &TypeRegistry,
+    name: &str,
+) -> Option<DynamicVariant> {
+    let TypeInfo::Enum(info) = value.get_represented_type_info()?
+    else {
+        return None;
+    };
+
+    Some(match info.variant(name)? {
+        VariantInfo::Unit(_) => DynamicVariant::Unit,
+        VariantInfo::Struct(info) => {
+            let mut fields = DynamicStruct::default();
+            for field in info.iter() {
+                let default = registry
+                    .get_type_data::<ReflectDefault>(field.type_id())?
+                    .default();
+                fields.insert_boxed(
+                    field.name(),
+                    default.into_partial_reflect(),
+                );
+            }
+            DynamicVariant::Struct(fields)
+        }
+        VariantInfo::Tuple(info) => {
+            let mut fields = DynamicTuple::default();
+            for field in info.iter() {
+                let default = registry
+                    .get_type_data::<ReflectDefault>(field.type_id())?
+                    .default();
+                fields.insert_boxed(default.into_partial_reflect());
+            }
+            DynamicVariant::Tuple(fields)
+        }
     })
 }
 
@@ -79,10 +153,10 @@ fn active(source: &dyn Source, world: &World) -> Option<String> {
 
 /// The variant, as a dropdown over the rest.
 ///
-/// `pick` is false for an enum carrying data, which then only names
-/// where it stands - moving it would mean inventing that data. The
-/// two look nothing alike, so they share a [`Frame`] and this comes
-/// back the same either way.
+/// `pick` is false when some variant of the type isn't
+/// [`constructible`], which then only names where it stands. The two
+/// look nothing alike, so they share a [`Frame`] and this comes back
+/// the same either way.
 pub(super) struct VariantPicker<'a> {
     pub source: &'a dyn Source,
     pub variants: Vec<String>,
@@ -225,10 +299,18 @@ fn option(
         let (source, variant) = (edited.boxed(), chosen.clone());
 
         commands.queue(move |world: &mut World| {
-            source.set(
-                world,
-                &DynamicEnum::new(variant, DynamicVariant::Unit),
-            );
+            let Some(value) = source.get(world) else {
+                return;
+            };
+            let dynamic = {
+                let registry =
+                    world.resource::<AppTypeRegistry>().read();
+                constructed(&*value, &registry, &variant)
+            };
+            if let Some(dynamic) = dynamic {
+                source
+                    .set(world, &DynamicEnum::new(variant, dynamic));
+            }
         });
     });
 }

--- a/editor/moxie_ui/src/inspector/tree.rs
+++ b/editor/moxie_ui/src/inspector/tree.rs
@@ -6,33 +6,22 @@
 //! Only a registered type stops the walk and becomes an editable row.
 
 use std::any::TypeId;
-use std::collections::HashSet;
 
 use bevy::ecs::change_detection::Tick;
 use bevy::input_focus::tab_navigation::TabGroup;
 use bevy::prelude::*;
 use bevy::reflect::{PartialReflect, ReflectRef, TypeRegistry};
-use bevy::ui_widgets::Activate;
-
 use bevy_fynix::ElementMutExt;
 use fynix_mock::composer::Composer;
 use fynix_mock::ui::ElementHandle;
 use fynix_mock::{elem, val};
 
 use super::{Field, ReflectInspect, enums};
-use crate::elements::{
-    ButtonElemCursor, Frame, FrameCursor, Icon, IconCursor, Label,
-    TintButton,
-};
+use crate::elements::{Frame, Icon, Label, TintButton};
+use crate::fold::{CHEVRON_OPEN, Foldable, Toggle};
 use crate::icons;
 use crate::reactive::{BevyHost, BevyUi};
 use crate::theme::EditorTheme;
-
-/// The fold chevron's own rotation, clockwise from the asset's
-/// resting up-pointing orientation: right when a group is folded
-/// shut, down when its children show.
-const CHEVRON_FOLDED: f32 = 90.0;
-const CHEVRON_OPEN: f32 = 180.0;
 
 /// One row the walk found.
 #[derive(Clone, PartialEq)]
@@ -244,42 +233,6 @@ fn shape_changed(field: Field) -> impl FnMut(&World, Entity) -> bool {
     }
 }
 
-/// Which sections are folded shut, keyed by the very field each one
-/// heads - so two inspectors never share state, and a component's own
-/// section folds apart from every group nested inside it.
-///
-/// This is UI state, not part of the reflected value, so it lives
-/// beside the tree rather than on it: folding a section must not read
-/// as the component's shape changing and trigger [`shape_changed`].
-#[derive(Resource, Default)]
-struct FoldedGroups(HashSet<Field>);
-
-fn is_folded(world: &World, field: &Field) -> bool {
-    world
-        .get_resource::<FoldedGroups>()
-        .is_some_and(|folded| folded.0.contains(field))
-}
-
-fn toggle_folded(world: &mut World, field: Field) {
-    let mut folded =
-        world.get_resource_or_insert_with(FoldedGroups::default);
-    if !folded.0.remove(&field) {
-        folded.0.insert(field);
-    }
-}
-
-/// Fires when `field`'s folded state flips, and on the first poll so
-/// a binding starts out in sync.
-fn fold_changed(field: Field) -> impl FnMut(&World, Entity) -> bool {
-    let mut seen: Option<bool> = None;
-    move |world, _| {
-        let current = is_folded(world, &field);
-        let fired = seen != Some(current);
-        seen = Some(current);
-        fired
-    }
-}
-
 /// Editable rows for everything reflectable under `root`, which is a
 /// whole component at the empty path.
 pub struct InspectorFields {
@@ -315,11 +268,9 @@ fn build_entries(ui: &mut BevyUi, root: &Field, entries: Vec<Entry>) {
             Entry::Leaf { path, type_id } => {
                 build_leaf(ui, root, path, type_id)
             }
-            Entry::Group {
-                path,
-                name,
-                children,
-            } => build_group(ui, root, path, name, children),
+            Entry::Group { name, children, .. } => {
+                build_group(ui, root, name, children)
+            }
             Entry::Variant {
                 path,
                 name,
@@ -403,7 +354,6 @@ fn build_variant(
 
     let inner = root.clone();
     ui.compose(Section {
-        field: field.clone(),
         name,
         body: move |ui: &mut BevyUi| {
             ui.compose(enums::VariantPicker {
@@ -419,15 +369,12 @@ fn build_variant(
 fn build_group(
     ui: &mut BevyUi,
     root: &Field,
-    path: String,
     name: String,
     children: Vec<Entry>,
 ) {
-    let group = root.child(&path);
     let inner = root.clone();
 
     ui.compose(Section {
-        field: group,
         name,
         body: move |ui: &mut BevyUi| {
             build_entries(ui, &inner, children);
@@ -437,12 +384,7 @@ fn build_group(
 
 /// A collapsible section: a header that folds it, and a body indented
 /// under a guide rail.
-///
-/// `field` is both what the fold is remembered against and what the
-/// section heads, so a whole component - the empty path, which the
-/// walk never hands a group - folds apart from every group inside it.
 pub struct Section<F> {
-    pub field: Field,
     pub name: String,
     pub body: F,
 }
@@ -454,19 +396,11 @@ impl<F: FnOnce(&mut BevyUi)> Composer<BevyHost> for Section<F> {
         self,
         ui: &mut BevyUi,
     ) -> ElementHandle<BevyHost, Frame> {
-        let Self { field, name, body } = self;
+        let Self { name, body } = self;
         let theme = ui.world.resource::<EditorTheme>().clone();
 
-        ui.elem(elem!(
-            Frame,
-            width = percent(100),
-            direction = FlexDirection::Column,
-            row_gap = px(2)
-        ))
-        .with(move |ui| {
-            let clicked = field.clone();
-            let glyph = field.clone();
-            ui.elem(elem!(
+        ui.compose(Foldable {
+            header: elem!(
                 !TintButton,
                 width = percent(100),
                 height = auto(),
@@ -485,68 +419,11 @@ impl<F: FnOnce(&mut BevyUi)> Composer<BevyHost> for Section<F> {
                     color = Some(theme.text_primary),
                     bold = true
                 )
-            ))
-            .observe(
-                move |_: On<Activate>, mut commands: Commands| {
-                    let field = clicked.clone();
-                    commands.queue(move |world: &mut World| {
-                        toggle_folded(world, field);
-                    });
-                },
-            )
-            .bind(
-                |button| button.icon().rotation(),
-                fold_changed(glyph.clone()),
-                move |world, _| {
-                    if is_folded(world, &glyph) {
-                        CHEVRON_FOLDED
-                    } else {
-                        CHEVRON_OPEN
-                    }
-                },
-            );
-
-            let body_field = field;
-            ui.elem(elem!(
-                Frame,
-                width = percent(100),
-                direction = FlexDirection::Row,
-                align = AlignItems::Stretch
-            ))
-            .bind(
-                |frame| frame.display(),
-                fold_changed(body_field.clone()),
-                move |world, _| {
-                    if is_folded(world, &body_field) {
-                        Display::None
-                    } else {
-                        Display::Flex
-                    }
-                },
-            )
-            .with(move |ui| {
-                // A guide rail beside the section's own rows, the way a
-                // tree view marks how deep a nested one sits - stretched
-                // to the block's height rather than sized by hand.
-                ui.elem(elem!(
-                    Frame,
-                    width = px(1),
-                    background = theme.palette.base[2]
-                ));
-                ui.elem(elem!(
-                    Frame,
-                    direction = FlexDirection::Column,
-                    flex_grow = 1.0f32,
-                    row_gap = px(4),
-                    padding = UiRect::new(
-                        px(9),
-                        Val::ZERO,
-                        Val::ZERO,
-                        Val::ZERO
-                    )
-                ))
-                .with(body);
-            });
+            ),
+            // Nothing else to mean: the whole header folds it.
+            toggle: Toggle::Header,
+            enabled: true,
+            body,
         })
         .handle()
     }

--- a/editor/moxie_ui/src/inspector/tree.rs
+++ b/editor/moxie_ui/src/inspector/tree.rs
@@ -13,11 +13,11 @@ use bevy::prelude::*;
 use bevy::reflect::{PartialReflect, ReflectRef, TypeRegistry};
 use bevy_fynix::ElementMutExt;
 use fynix_mock::composer::Composer;
-use fynix_mock::ui::ElementHandle;
+use fynix_mock::ui::{ElementHandle, ElementMut};
 use fynix_mock::{elem, val};
 
 use super::{Field, ReflectInspect, enums};
-use crate::elements::{Frame, Icon, Label, TintButton};
+use crate::elements::{ButtonElem, Frame, Icon, Label, TintButton};
 use crate::fold::{CHEVRON_OPEN, Foldable, Toggle};
 use crate::icons;
 use crate::reactive::{BevyHost, BevyUi};
@@ -423,6 +423,12 @@ impl<F: FnOnce(&mut BevyUi)> Composer<BevyHost> for Section<F> {
             // Nothing else to mean: the whole header folds it.
             toggle: Toggle::Header,
             enabled: true,
+            on_header: |_: ElementMut<
+                '_,
+                '_,
+                BevyHost,
+                ButtonElem,
+            >| {},
             body,
         })
         .handle()

--- a/editor/moxie_ui/src/inspector/tree.rs
+++ b/editor/moxie_ui/src/inspector/tree.rs
@@ -68,14 +68,12 @@ fn push_entry(
     }
 
     if let Some(variants) = enums::variants(value) {
-        let pick = enums::all_unit(value);
+        let pick = enums::constructible(value, registry);
         out.push(Entry::Variant {
             path: path.to_string(),
             name: name.to_string(),
             variants,
             pick,
-            // A unit variant has no fields, so this is empty for
-            // every enum that can be freely picked.
             children: collect_entries(registry, value, path),
         });
         return;

--- a/editor/moxie_ui/src/lib.rs
+++ b/editor/moxie_ui/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 
 pub mod elements;
+pub mod fold;
 pub mod icons;
 pub mod inspector;
 pub mod motion;

--- a/editor/moxie_ui/src/reactive.rs
+++ b/editor/moxie_ui/src/reactive.rs
@@ -76,17 +76,45 @@ where
     }
 }
 
-/// Fires when the watched node's `C` differs from the last poll.
+/// Fires when the node's `C` was written since the last poll, and on
+/// the first poll.
 ///
-/// The entity-local counterpart to [`resource_changed`]: state for a
-/// single widget instance (a popup's open/closed, a field's edit
-/// buffer) belongs on that widget's own node, not in a global
-/// `Resource` that every instance of the widget would have to share.
-/// `C` absent reads as unchanged, not a rebuild — a node that hasn't
-/// had its state inserted yet is not yet ready to build.
-pub fn component_changed<C: Component + Clone + PartialEq>()
+/// State belonging to one widget instance lives on its own node
+/// rather than in a `Resource` every instance would share. Rides the
+/// tick, so [`value_changed`] is what to reach for when the value is
+/// what matters.
+pub fn component_changed<C: Component>()
 -> impl FnMut(&World, Entity) -> bool + Send + Sync + 'static {
-    value_changed(|world, node| world.get::<C>(node).cloned())
+    let mut seen: Option<Option<Tick>> = None;
+    move |world, node| {
+        let current = component_tick::<C>(world, node);
+        let fired = seen != Some(current);
+        seen = Some(current);
+        fired
+    }
+}
+
+/// Same, for `C` on some other entity than the node.
+pub fn component_changed_on<C: Component>(
+    entity: Entity,
+) -> impl FnMut(&World, Entity) -> bool + Send + Sync + 'static {
+    let mut seen: Option<Option<Tick>> = None;
+    move |world, _| {
+        let current = component_tick::<C>(world, entity);
+        let fired = seen != Some(current);
+        seen = Some(current);
+        fired
+    }
+}
+
+/// When `C` on `entity` was last written.
+fn component_tick<C: Component>(
+    world: &World,
+    entity: Entity,
+) -> Option<Tick> {
+    let ComponentTicks { changed, .. } =
+        world.get_entity(entity).ok()?.get_change_ticks::<C>()?;
+    Some(changed)
 }
 
 /// Fires when the current `S` differs from the last poll.

--- a/editor/moxie_ui/src/widgets/dock.rs
+++ b/editor/moxie_ui/src/widgets/dock.rs
@@ -25,8 +25,8 @@ pub use registry::{
     DockWindowBuildFn, DockWindowDescriptor, WindowRegistry,
 };
 pub use split::{
-    Panel, PanelGroup, PanelHandle, SplitPanelPlugin, panel,
-    panel_group, panel_handle,
+    HANDLE_SIZE, Panel, PanelGroup, PanelHandle, SplitPanelPlugin,
+    panel, panel_group, panel_handle,
 };
 pub use tabs::DockTabRow;
 pub use tree::{

--- a/editor/moxie_ui/src/widgets/dock/add_popup.rs
+++ b/editor/moxie_ui/src/widgets/dock/add_popup.rs
@@ -158,7 +158,7 @@ fn build_popup(ui: &mut BevyUi) {
         padding = UiRect::all(px(4)),
         radius = px(6),
         background = Color::srgba(0.11, 0.10, 0.11, 0.98),
-        z = Some(181)
+        z = 181
     ))
     .with(move |ui| build_rows(ui, area));
 }

--- a/editor/moxie_ui/src/widgets/dock/reconcile.rs
+++ b/editor/moxie_ui/src/widgets/dock/reconcile.rs
@@ -23,11 +23,15 @@ use super::tree::{
     DockAreaStyle, DockLeaf, DockNode, DockSplit, DockTree, NodeId,
     SplitAxis, TabId,
 };
+use crate::elements::FrameCursor;
 use crate::elements::dock::{
-    Area, AreaCursor, DockHost, SplitGroup, SplitHandle, SplitPanel,
-    SplitPanelCursor, TabContent, TabContentCursor,
+    Area, AreaCursor, DockHost, SplitGroup, SplitHandle,
+    SplitHandleCursor, SplitPanel, SplitPanelCursor, TabContent,
+    TabContentCursor, handle_bar, handle_line,
 };
+use crate::motion::{HOVER, MotionExt};
 use crate::reactive::{BevyUi, resource_changed, structure_changed};
+use crate::theme::EditorTheme;
 
 pub struct ReconcilePlugin;
 
@@ -121,6 +125,8 @@ fn build_split(id: NodeId, split: DockSplit, ui: &mut BevyUi) {
     let a_visible = leaf_visible(ui.world, split.a);
     let b_visible = leaf_visible(ui.world, split.b);
     let handle_visible = a_visible && b_visible;
+    let line_color =
+        ui.world.resource::<EditorTheme>().palette.base[2];
 
     ui.elem(elem!(SplitGroup, node = id, axis = flex_direction))
         .with(move |ui| {
@@ -130,8 +136,15 @@ fn build_split(id: NodeId, split: DockSplit, ui: &mut BevyUi) {
                 SplitHandle,
                 node = id,
                 axis = flex_direction,
-                visible = handle_visible
-            ));
+                visible = handle_visible,
+                line = handle_line(flex_direction, line_color),
+                bar = handle_bar(flex_direction)
+            ))
+            .lit(
+                |handle| handle.bar().background(),
+                HOVER,
+                HOVER,
+            );
 
             build_panel(id, split.b, false, b_visible, ui);
         });

--- a/editor/moxie_ui/src/widgets/dock/reconcile.rs
+++ b/editor/moxie_ui/src/widgets/dock/reconcile.rs
@@ -129,6 +129,7 @@ fn build_split(id: NodeId, split: DockSplit, ui: &mut BevyUi) {
             ui.elem(elem!(
                 SplitHandle,
                 node = id,
+                axis = flex_direction,
                 visible = handle_visible
             ));
 

--- a/editor/moxie_ui/src/widgets/dock/split.rs
+++ b/editor/moxie_ui/src/widgets/dock/split.rs
@@ -32,8 +32,7 @@ impl Plugin for SplitPanelPlugin {
 }
 
 /// A drag handle's width/height, and its hit area.
-pub const HANDLE_SIZE: f32 = 3.0;
-const HANDLE_HOVER_COLOR: Color = Color::srgba(1.0, 1.0, 1.0, 0.12);
+pub const HANDLE_SIZE: f32 = 8.0;
 
 #[derive(Component)]
 pub struct PanelGroup {
@@ -47,11 +46,6 @@ pub struct Panel {
 
 #[derive(Component)]
 pub struct PanelHandle;
-
-/// Present on a handle while it's being dragged, so the highlight
-/// stays visible for the whole drag even if the cursor leaves it.
-#[derive(Component)]
-struct HandleDragging;
 
 pub fn panel_group<
     C: SpawnableList<ChildOf> + Send + Sync + 'static,
@@ -175,8 +169,6 @@ fn on_handle_added(
         .insert(EntityCursor::System(cursor_icon))
         .observe(on_handle_drag_start)
         .observe(on_handle_drag_end)
-        .observe(on_handle_hover)
-        .observe(on_handle_unhover)
         .observe(handle_panel_drag);
 }
 
@@ -185,17 +177,11 @@ fn on_handle_drag_start(
     handles: Query<&ChildOf, With<PanelHandle>>,
     nodes: Query<&Node>,
     mut override_cursor: ResMut<OverrideCursor>,
-    mut commands: Commands,
 ) {
     let handle = trigger.event_target();
     let Ok(&ChildOf(parent)) = handles.get(handle) else {
         return;
     };
-    // Keep the highlight shown for the whole drag.
-    commands.entity(handle).insert((
-        HandleDragging,
-        BackgroundColor(HANDLE_HOVER_COLOR),
-    ));
     let Ok(node) = nodes.get(parent) else {
         return;
     };
@@ -210,17 +196,11 @@ fn on_handle_drag_end(
     handles: Query<&ChildOf, With<PanelHandle>>,
     nodes: Query<&Node>,
     mut override_cursor: ResMut<OverrideCursor>,
-    mut commands: Commands,
 ) {
     let handle = trigger.event_target();
     let Ok(&ChildOf(parent)) = handles.get(handle) else {
         return;
     };
-    // End of drag: drop the marker and clear the highlight.
-    commands
-        .entity(handle)
-        .remove::<HandleDragging>()
-        .insert(BackgroundColor(Color::NONE));
     let Ok(node) = nodes.get(parent) else {
         return;
     };
@@ -228,28 +208,6 @@ fn on_handle_drag_end(
     if override_cursor.0 == Some(EntityCursor::System(cursor_icon)) {
         override_cursor.0 = None;
     }
-}
-
-fn on_handle_hover(
-    trigger: On<Pointer<Over>>,
-    mut commands: Commands,
-) {
-    commands
-        .entity(trigger.event_target())
-        .insert(BackgroundColor(HANDLE_HOVER_COLOR));
-}
-
-fn on_handle_unhover(
-    trigger: On<Pointer<Out>>,
-    dragging: Query<(), With<HandleDragging>>,
-    mut commands: Commands,
-) {
-    let handle = trigger.event_target();
-    // Leaving the handle mid-drag keeps the highlight.
-    if dragging.contains(handle) {
-        return;
-    }
-    commands.entity(handle).insert(BackgroundColor(Color::NONE));
 }
 
 fn handle_panel_drag(

--- a/editor/moxie_ui/src/widgets/dock/split.rs
+++ b/editor/moxie_ui/src/widgets/dock/split.rs
@@ -31,7 +31,8 @@ impl Plugin for SplitPanelPlugin {
     }
 }
 
-const HANDLE_SIZE: f32 = 3.0;
+/// A drag handle's width/height, and its hit area.
+pub const HANDLE_SIZE: f32 = 3.0;
 const HANDLE_HOVER_COLOR: Color = Color::srgba(1.0, 1.0, 1.0, 0.12);
 
 #[derive(Component)]


### PR DESCRIPTION
The hierarchy panel also shows the name of the entities now!

Additional bug fix: it also filters out entities that are not being animated (i.e. entities without the `EntityUid` component)

<img width="1392" height="864" alt="image" src="https://github.com/user-attachments/assets/487865ed-ce9a-480a-8e34-c9a2ea7dc098" />
