### PR TITLE
Fix watch recursive resolution frame lag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See @AGENTS.md.
+@AGENTS.md

--- a/crates/bevy_fynix/src/lib.rs
+++ b/crates/bevy_fynix/src/lib.rs
@@ -89,7 +89,7 @@ pub fn theme_mut<Theme: Send + Sync + 'static>(
     kernel.into_inner().theme_mut()
 }
 
-/// Build `root` on the next flush, and never again.
+/// Build `root` immediately, and never again.
 ///
 /// Everything reactive below it is declared inside `build`. Call it
 /// once per root, after spawning that root.
@@ -100,10 +100,15 @@ pub fn watch_root<Theme: Send + Sync + 'static>(
 ) {
     let mut pending = true;
 
-    world.resource_mut::<BevyFynix<Theme>>().watch(
-        root,
-        move |_, _| core::mem::take(&mut pending),
-        build,
+    world.resource_scope::<BevyFynix<Theme>, _>(
+        |world, mut kernel| {
+            kernel.watch(
+                root,
+                move |_, _| core::mem::take(&mut pending),
+                build,
+                world,
+            );
+        },
     );
 }
 

--- a/crates/fynix_mock/src/lib.rs
+++ b/crates/fynix_mock/src/lib.rs
@@ -110,23 +110,32 @@ impl<H: Host> Fynix<H> {
     }
 
     /// The theme, to edit in place. Any edit rebuilds the whole tree
-    /// on the next [`flush`](Self::flush).
+    /// on the next [`Self::flush`].
     pub fn theme_mut(&mut self) -> &mut H::Theme {
         self.theme_dirty = true;
         &mut self.theme
     }
 
     /// Rebuild the subtree under `root` whenever `changed` fires.
+    /// Mirrors [`ElementMut::watch`](crate::ui::ElementMut::watch).
     ///
     /// This is the bootstrap watcher. Every other one is added
-    /// through [`ElementMut::watch`](crate::ui::ElementMut::watch)
-    /// inside a build.
+    /// through `ElementMut::watch` inside a build.
     pub fn watch(
         &mut self,
         root: H::Node,
         changed: impl ChangedFn<H>,
         build: impl BuildFn<H>,
+        world: &mut H::World,
     ) {
+        let mut changed = changed;
+        if changed(world, root) {
+            clear_children::<H>(world, root);
+            let mut ui =
+                Ui::new(world, root, &mut self.records, &self.theme);
+            build(&mut ui);
+        }
+
         self.watchers.push(Watcher {
             root,
             changed: Box::new(changed),
@@ -271,7 +280,10 @@ impl<H: Host> Fynix<H> {
 
 /// Despawn the kernel's children of `root`. The sweep in
 /// [`Fynix::flush`] then drops whatever those nodes left behind.
-fn clear_children<H: Host>(world: &mut H::World, root: H::Node) {
+pub(crate) fn clear_children<H: Host>(
+    world: &mut H::World,
+    root: H::Node,
+) {
     for child in H::children(world, root) {
         H::despawn(world, child);
     }

--- a/crates/fynix_mock/src/ui.rs
+++ b/crates/fynix_mock/src/ui.rs
@@ -275,8 +275,9 @@ impl<H: Host, E: Element<H>> ElementMut<'_, '_, H, E> {
         ElementHandle::new(self.node)
     }
 
-    /// Rebuild this element's children whenever `changed` fires. First
-    /// runs on the next flush.
+    /// Rebuild this element's children whenever `changed` fires,
+    /// polled immediately so a `.watch()` reached from inside
+    /// another one's build gets its own first look right away.
     ///
     /// Use this *or* [`Self::with`], not both: a fire clears whatever
     /// children the node has.
@@ -285,6 +286,18 @@ impl<H: Host, E: Element<H>> ElementMut<'_, '_, H, E> {
         changed: impl ChangedFn<H>,
         build: impl BuildFn<H>,
     ) -> &mut Self {
+        let mut changed = changed;
+        if changed(self.ui.world, self.node) {
+            crate::clear_children::<H>(self.ui.world, self.node);
+            let mut child = Ui::new(
+                self.ui.world,
+                self.node,
+                self.ui.records,
+                self.ui.theme,
+            );
+            build(&mut child);
+        }
+
         self.ui.records.spawned.push(Watcher {
             root: self.node,
             changed: Box::new(changed),

--- a/crates/fynix_mock/tests/kernel.rs
+++ b/crates/fynix_mock/tests/kernel.rs
@@ -8,7 +8,7 @@ use fynix_mock::Fynix;
 use fynix_mock::elem;
 use fynix_mock::host::Host;
 
-/// Fires on the first flush and never again, the way a bootstrap
+/// Fires on the first call and never again, the way a bootstrap
 /// build does. A stateful predicate consumes its own signal.
 fn once() -> impl FnMut(&World, usize) -> bool + Send + Sync + 'static
 {
@@ -24,25 +24,31 @@ fn only_child(world: &World, root: usize) -> usize {
 }
 
 #[test]
-fn flush_builds_what_a_watcher_declares() {
+fn watch_builds_immediately_when_its_predicate_fires() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label));
-    });
-
-    assert!(Backend::children(&world, root).is_empty());
-
-    kernel.flush(&mut world);
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label));
+        },
+        &mut world,
+    );
 
     let label = only_child(&world, root);
     assert_eq!(world.get(label).text, "Label");
     assert_eq!(world.get(label).size, 13);
+
+    // `once()`'s first call already happened above, so a flush right
+    // after does not rebuild.
+    kernel.flush(&mut world);
+    assert_eq!(only_child(&world, root), label, "not rebuilt");
 }
 
 #[test]
-fn flush_builds_nothing_when_no_predicate_fires() {
+fn watch_builds_nothing_when_its_predicate_never_fires() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
@@ -52,7 +58,10 @@ fn flush_builds_nothing_when_no_predicate_fires() {
         |ui| {
             ui.elem(elem!(Label));
         },
+        &mut world,
     );
+
+    assert!(Backend::children(&world, root).is_empty());
 
     kernel.flush(&mut world);
 
@@ -64,17 +73,21 @@ fn binding_writes_and_patches_one_field() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label)).bind(
-            |label| label.text(),
-            |world, _| world.source.changed,
-            |world, _| world.source.text.clone(),
-        );
-    });
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label)).bind(
+                |label| label.text(),
+                |world, _| world.source.changed,
+                |world, _| world.source.text.clone(),
+            );
+        },
+        &mut world,
+    );
 
-    // Builds, but the binding's predicate has not fired, so the
-    // element still holds what it was built with.
-    kernel.flush(&mut world);
+    // Built immediately; the binding's own predicate has not fired,
+    // so the element still holds what it was built with.
     let label = only_child(&world, root);
     assert_eq!(world.get(label).text, "Label");
 
@@ -94,15 +107,19 @@ fn binding_stays_quiet_until_its_predicate_fires() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label)).bind(
-            |label| label.text(),
-            |world, _| world.source.changed,
-            |world, _| world.source.text.clone(),
-        );
-    });
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label)).bind(
+                |label| label.text(),
+                |world, _| world.source.changed,
+                |world, _| world.source.text.clone(),
+            );
+        },
+        &mut world,
+    );
 
-    kernel.flush(&mut world);
     let label = only_child(&world, root);
 
     // A new value, but nothing says so.
@@ -117,13 +134,17 @@ fn rebuild_replaces_the_children() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
+    // False at registration, so nothing builds until `changed` is
+    // set below.
     kernel.watch(
         root,
         |world: &World, _| world.source.changed,
         |ui| {
             ui.elem(elem!(Label));
         },
+        &mut world,
     );
+    assert!(Backend::children(&world, root).is_empty());
 
     world.source.changed = true;
     kernel.flush(&mut world);
@@ -144,15 +165,19 @@ fn dead_node_is_not_patched() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label)).bind(
-            |label| label.text(),
-            |world, _| world.source.changed,
-            |world, _| world.source.text.clone(),
-        );
-    });
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label)).bind(
+                |label| label.text(),
+                |world, _| world.source.changed,
+                |world, _| world.source.text.clone(),
+            );
+        },
+        &mut world,
+    );
 
-    kernel.flush(&mut world);
     let label = only_child(&world, root);
 
     // Despawned behind the kernel's back. A binding kept against a
@@ -172,12 +197,15 @@ fn swept_node_takes_its_element_with_it() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
+    // False at registration, so nothing builds until `changed` is
+    // set below.
     kernel.watch(
         root,
         |world: &World, _| world.source.changed,
         |ui| {
             ui.elem(elem!(Label));
         },
+        &mut world,
     );
 
     world.source.changed = true;
@@ -209,9 +237,14 @@ fn dead_root_takes_its_watcher_with_it() {
     // without taking the whole world with it.
     let branch = Backend::spawn(&mut world, root);
 
-    kernel.watch(branch, once(), |ui| {
-        ui.elem(elem!(Label));
-    });
+    kernel.watch(
+        branch,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label));
+        },
+        &mut world,
+    );
     assert_eq!(kernel.watcher_len(), 1);
 
     kernel.flush(&mut world);
@@ -228,15 +261,19 @@ fn dead_node_takes_its_bindings_with_it() {
     let (mut world, root) = World::with_root();
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label)).bind(
-            |label| label.text(),
-            |world, _| world.source.changed,
-            |world, _| world.source.text.clone(),
-        );
-    });
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label)).bind(
+                |label| label.text(),
+                |world, _| world.source.changed,
+                |world, _| world.source.text.clone(),
+            );
+        },
+        &mut world,
+    );
 
-    kernel.flush(&mut world);
     let label = only_child(&world, root);
     assert_eq!(kernel.binding_len(), 1);
 

--- a/crates/fynix_mock/tests/styles.rs
+++ b/crates/fynix_mock/tests/styles.rs
@@ -215,9 +215,8 @@ fn the_builder_takes_a_styled_element_whole() {
         |ui| {
             ui.elem(elem!(!Title, text = "Save"));
         },
+        &mut world,
     );
-
-    kernel.flush(&mut world);
 
     let children = Backend::children(&world, root);
     assert_eq!(world.get(children[0]).text, "Save");

--- a/crates/fynix_mock/tests/transitions.rs
+++ b/crates/fynix_mock/tests/transitions.rs
@@ -34,13 +34,21 @@ fn travelling() -> (World, usize, Fynix<Backend>, usize) {
     world.delta = 0.25;
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label, size = 0u32)).transition(
-            |label| label.size(),
-            Transition::secs(1.0, <u32 as Interpolation<()>>::interp)
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label, size = 0u32)).transition(
+                |label| label.size(),
+                Transition::secs(
+                    1.0,
+                    <u32 as Interpolation<()>>::interp,
+                )
                 .ease(ease::linear),
-        );
-    });
+            );
+        },
+        &mut world,
+    );
     kernel.flush(&mut world);
 
     let label = only_child(&world, root);
@@ -120,9 +128,14 @@ fn element_keeps_the_base_while_a_lane_is_in_flight() {
     // Whatever the lane shows, the element is still what the cascade
     // left: a rebuild starts from the base, not from mid flight.
     kernel.unwatch(root);
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(Label, size = 0u32));
-    });
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(Label, size = 0u32));
+        },
+        &mut world,
+    );
     kernel.flush(&mut world);
 
     let rebuilt = only_child(&world, root);
@@ -210,9 +223,14 @@ fn style_carries_what_moves_as_well_as_what_it_looks_like() {
     world.delta = 0.5;
     let mut kernel = Fynix::new(());
 
-    kernel.watch(root, once(), |ui| {
-        ui.elem(elem!(!Grows, text = "Save"));
-    });
+    kernel.watch(
+        root,
+        once(),
+        |ui| {
+            ui.elem(elem!(!Grows, text = "Save"));
+        },
+        &mut world,
+    );
     kernel.flush(&mut world);
 
     let label = only_child(&world, root);

--- a/editor/docs/backlog.md
+++ b/editor/docs/backlog.md
@@ -154,84 +154,33 @@ frame, at a time instead of appearing whole.
 Real fynix (`~/develop/projects/rust/fynix`) doesn't have this: its
 `ctx.watch()` (`crates/fynix/src/ctx.rs`) builds the subtree inline,
 synchronously, right there, and only arms the watcher for later
-changes afterward. Matching that without touching any of
-`fynix_mock`'s predicates - all of which lean on "always true on
-first call" and are used elsewhere too - means building synchronously
-in `watch()` itself, then polling the predicate once immediately to
-consume that free first-fire, so `flush()`'s own first real look at
-the watcher only fires on a change after the build that just
-happened, not the one it already did.
+changes afterward.
 
-- [ ] `ElementMut::watch` (`crates/fynix_mock/src/ui.rs`): build via
-      a fresh `Ui::new(self.ui.world, self.node, ...)` immediately,
-      then call `changed(self.ui.world, self.node)` once to prime it,
-      before pushing the `Watcher` into `records.spawned`:
-
-      ```rust
-      pub fn watch(
-          &mut self,
-          changed: impl ChangedFn<H>,
-          build: impl BuildFn<H>,
-      ) -> &mut Self {
-          let mut child = Ui::new(
-              self.ui.world,
-              self.node,
-              self.ui.records,
-              self.ui.theme,
-          );
-          build(&mut child);
-
-          let mut changed = changed;
-          // Consumes the "first call" `changed` always reports, so
-          // the flush loop's own first look at this watcher only
-          // fires on a real change after the build above, not the
-          // one that just happened.
-          changed(self.ui.world, self.node);
-
-          self.ui.records.spawned.push(Watcher {
-              root: self.node,
-              changed: Box::new(changed),
-              build: Box::new(build),
-          });
-          self
-      }
-      ```
-- [ ] `Fynix::watch` (`crates/fynix_mock/src/lib.rs`, the bootstrap/
-      root entry point) the same way, for consistency - it only
-      removes a one-frame blank window at startup, lower stakes than
-      the nested case but the same shape of fix. Needs `world: &mut
-      H::World` threaded in, which it doesn't take today; check
-      `reactive::watch_root`'s call site for the signature change:
-
-      ```rust
-      pub fn watch(
-          &mut self,
-          root: H::Node,
-          changed: impl ChangedFn<H>,
-          build: impl BuildFn<H>,
-          world: &mut H::World,
-      ) {
-          let mut ui = Ui::new(world, root, &mut self.records, &self.theme);
-          build(&mut ui);
-
-          let mut changed = changed;
-          changed(world, root);
-
-          self.watchers.push(Watcher {
-              root,
-              changed: Box::new(changed),
-              build: Box::new(build),
-          });
-      }
-      ```
-- [ ] Leave `flush()`'s loop, `Records::spawned`, the `Watcher`
-      struct, and every predicate in `reactive.rs` alone - all of it
-      stays exactly what it already does for a watcher after its
-      first poll.
-- [ ] Verify by expanding several nested hierarchy rows and asset
-      folders, then reordering or adding a sibling near the root: the
-      whole open subtree should reappear in one frame, not visibly
-      settle level by level.
+- [x] `ElementMut::watch` and `Fynix::watch` now poll `changed` once
+      immediately and build right there if it fires, rather than only
+      registering for `flush()` to find later. Simpler than the fix
+      first sketched here: that one built unconditionally and called
+      `changed` a second time only to consume its guaranteed-true
+      first call; polling first and gating the build on the result
+      needs one call, not two, and also does the right thing for a
+      predicate that legitimately starts out false (nothing builds
+      until it actually fires) - `Fynix::watch` gained a `world: &mut
+      H::World` parameter for this, so `bevy_fynix::watch_root` now
+      reaches it through `World::resource_scope` rather than
+      `resource_mut`, the same way `with_kernel` already did.
+- [x] Both call `clear_children` before that immediate build, not
+      only `flush()`'s loop - missing from the first sketch, and
+      necessary: a node can already have children when `.watch()` is
+      called (`unwatch` then `watch` again, say), and skipping it
+      would build a second subtree alongside the first instead of
+      replacing it.
+- [x] `crates/fynix_mock/tests/kernel.rs`, `transitions.rs`,
+      `styles.rs` updated for the new signature and behavior; the
+      whole suite passes.
+- [ ] Verify in the running editor: expanding several nested hierarchy
+      rows and asset folders, then reordering or adding a sibling near
+      the root - the whole open subtree should reappear in one frame,
+      not visibly settle level by level.
 
 ## Assigning and treating assets in the inspector
 


### PR DESCRIPTION
Fixes the "flash" when a watcher runs to rebuild the UI.

Watchers now builds itself on creation which in turn builds their child on creation, and so on recursively.