### PR TITLE
Remove the `Any` variant from `motiongfx_scene`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3912,6 +3912,7 @@ dependencies = [
  "criterion",
  "field_path",
  "hashbrown 0.17.1",
+ "libm",
  "motiongfx_interp",
  "nonempty",
  "tracing",

--- a/assets/projects/hello_world/hello_world.mox
+++ b/assets/projects/hello_world/hello_world.mox
@@ -2,92 +2,59 @@
   world: (
     resources: {},
     entities: {
-      4294966551: (
+      4294966390: (
         components: {
           "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::Children": ([
-            4294966552,
-            4294966556,
-          ]),
-          "bevy_transform::components::transform::Transform": (
-            translation: (0.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (1.0, 1.0, 1.0),
-          ),
-          "moxie::SceneRoot": (),
-        },
-      ),
-      4294966552: (
-        components: {
-          "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966551),
-          "bevy_ecs::hierarchy::Children": ([
-            4294966553,
-            4294966554,
-            4294966555,
-          ]),
-          "bevy_ecs::name::Name": "Solids",
-          "bevy_motiongfx::scene::id::EntityUid": ("59af9736-3ea8-49ad-adb2-88703abbf39d"),
-          "bevy_transform::components::transform::Transform": (
-            translation: (0.0, 1.2, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (1.0, 1.0, 1.0),
-          ),
-        },
-      ),
-      4294966553: (
-        components: {
-          "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966552),
-          "bevy_ecs::name::Name": "Solids 0",
-          "bevy_mesh::components::Mesh3d": (Path("meshes/cube.glb#Mesh0/Primitive0")),
-          "bevy_motiongfx::scene::id::EntityUid": ("90d72875-f1d4-4af4-bf0e-d19913343106"),
-          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
-          "bevy_transform::components::transform::Transform": (
-            translation: (-2.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (0.0, 0.0, 0.0),
-          ),
-        },
-      ),
-      4294966554: (
-        components: {
-          "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966552),
-          "bevy_ecs::name::Name": "Solids 1",
-          "bevy_mesh::components::Mesh3d": (Path("meshes/sphere.glb#Mesh0/Primitive0")),
-          "bevy_motiongfx::scene::id::EntityUid": ("8f231763-6ed4-45ee-8a0f-78d80ee3f8b0"),
-          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
-          "bevy_transform::components::transform::Transform": (
-            translation: (0.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (0.0, 0.0, 0.0),
-          ),
-        },
-      ),
-      4294966555: (
-        components: {
-          "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966552),
-          "bevy_ecs::name::Name": "Solids 2",
-          "bevy_mesh::components::Mesh3d": (Path("meshes/monkey.glb#Mesh0/Primitive0")),
-          "bevy_motiongfx::scene::id::EntityUid": ("15860121-b882-4dd0-94d5-6f8563c80178"),
+          "bevy_ecs::hierarchy::ChildOf": (4294966393),
+          "bevy_ecs::name::Name": "Flats 2",
+          "bevy_mesh::components::Mesh3d": (Path("meshes/cylinder_flat.glb#Mesh0/Primitive0")),
+          "bevy_motiongfx::scene::id::EntityUid": ("b8d1ffdc-abaa-4695-9f3a-e018e054bbb4"),
           "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
           "bevy_transform::components::transform::Transform": (
             translation: (2.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (0.0, 0.0, 0.0),
+            rotation: (0.0, 1.0, 0.0, -0.00000004371139),
+            scale: (1.0, 1.0, 1.0),
           ),
         },
       ),
-      4294966556: (
+      4294966391: (
         components: {
           "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966551),
+          "bevy_ecs::hierarchy::ChildOf": (4294966393),
+          "bevy_ecs::name::Name": "Flats 1",
+          "bevy_mesh::components::Mesh3d": (Path("meshes/sphere_flat.glb#Mesh0/Primitive0")),
+          "bevy_motiongfx::scene::id::EntityUid": ("f13cccc6-fe99-4b08-83ea-8e2047a3081e"),
+          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
+          "bevy_transform::components::transform::Transform": (
+            translation: (0.0, 0.0, 0.0),
+            rotation: (0.0, 1.0, 0.0, -0.00000004371139),
+            scale: (1.0, 1.0, 1.0),
+          ),
+        },
+      ),
+      4294966392: (
+        components: {
+          "bevy_camera::visibility::Visibility": Inherited,
+          "bevy_ecs::hierarchy::ChildOf": (4294966393),
+          "bevy_ecs::name::Name": "Flats 0",
+          "bevy_mesh::components::Mesh3d": (Path("meshes/plane.glb#Mesh0/Primitive0")),
+          "bevy_motiongfx::scene::id::EntityUid": ("a2ec0ac9-1cf4-4234-a11e-32bc673db0b4"),
+          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
+          "bevy_transform::components::transform::Transform": (
+            translation: (-2.0, 0.0, 0.0),
+            rotation: (0.0, 1.0, 0.0, -0.00000004371139),
+            scale: (1.0, 1.0, 1.0),
+          ),
+        },
+      ),
+      4294966393: (
+        components: {
+          "bevy_camera::visibility::Visibility": Inherited,
+          "bevy_ecs::hierarchy::ChildOf": (4294966398),
           "bevy_ecs::hierarchy::Children": ([
-            4294966557,
-            4294966558,
-            4294966559,
+            4294966392,
+            4294966391,
+            4294966390,
           ]),
           "bevy_ecs::name::Name": "Flats",
           "bevy_motiongfx::scene::id::EntityUid": ("908e820e-55ce-42d0-9980-1251fe0de724"),
@@ -98,49 +65,82 @@
           ),
         },
       ),
-      4294966557: (
+      4294966394: (
         components: {
           "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966556),
-          "bevy_ecs::name::Name": "Flats 0",
-          "bevy_mesh::components::Mesh3d": (Path("meshes/plane.glb#Mesh0/Primitive0")),
-          "bevy_motiongfx::scene::id::EntityUid": ("a2ec0ac9-1cf4-4234-a11e-32bc673db0b4"),
-          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
-          "bevy_transform::components::transform::Transform": (
-            translation: (-2.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (0.0, 0.0, 0.0),
-          ),
-        },
-      ),
-      4294966558: (
-        components: {
-          "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966556),
-          "bevy_ecs::name::Name": "Flats 1",
-          "bevy_mesh::components::Mesh3d": (Path("meshes/sphere_flat.glb#Mesh0/Primitive0")),
-          "bevy_motiongfx::scene::id::EntityUid": ("f13cccc6-fe99-4b08-83ea-8e2047a3081e"),
-          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
-          "bevy_transform::components::transform::Transform": (
-            translation: (0.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (0.0, 0.0, 0.0),
-          ),
-        },
-      ),
-      4294966559: (
-        components: {
-          "bevy_camera::visibility::Visibility": Inherited,
-          "bevy_ecs::hierarchy::ChildOf": (4294966556),
-          "bevy_ecs::name::Name": "Flats 2",
-          "bevy_mesh::components::Mesh3d": (Path("meshes/cylinder_flat.glb#Mesh0/Primitive0")),
-          "bevy_motiongfx::scene::id::EntityUid": ("b8d1ffdc-abaa-4695-9f3a-e018e054bbb4"),
+          "bevy_ecs::hierarchy::ChildOf": (4294966397),
+          "bevy_ecs::name::Name": "Solids 2",
+          "bevy_mesh::components::Mesh3d": (Path("meshes/monkey.glb#Mesh0/Primitive0")),
+          "bevy_motiongfx::scene::id::EntityUid": ("15860121-b882-4dd0-94d5-6f8563c80178"),
           "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
           "bevy_transform::components::transform::Transform": (
             translation: (2.0, 0.0, 0.0),
-            rotation: (0.0, 0.0, 0.0, 1.0),
-            scale: (0.0, 0.0, 0.0),
+            rotation: (0.0, 1.0, 0.0, -0.00000004371139),
+            scale: (1.0, 1.0, 1.0),
           ),
+        },
+      ),
+      4294966395: (
+        components: {
+          "bevy_camera::visibility::Visibility": Inherited,
+          "bevy_ecs::hierarchy::ChildOf": (4294966397),
+          "bevy_ecs::name::Name": "Solids 1",
+          "bevy_mesh::components::Mesh3d": (Path("meshes/sphere.glb#Mesh0/Primitive0")),
+          "bevy_motiongfx::scene::id::EntityUid": ("8f231763-6ed4-45ee-8a0f-78d80ee3f8b0"),
+          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
+          "bevy_transform::components::transform::Transform": (
+            translation: (0.0, 0.0, 0.0),
+            rotation: (0.0, 1.0, 0.0, -0.00000004371139),
+            scale: (1.0, 1.0, 1.0),
+          ),
+        },
+      ),
+      4294966396: (
+        components: {
+          "bevy_camera::visibility::Visibility": Inherited,
+          "bevy_ecs::hierarchy::ChildOf": (4294966397),
+          "bevy_ecs::name::Name": "Solids 0",
+          "bevy_mesh::components::Mesh3d": (Path("meshes/cube.glb#Mesh0/Primitive0")),
+          "bevy_motiongfx::scene::id::EntityUid": ("90d72875-f1d4-4af4-bf0e-d19913343106"),
+          "bevy_pbr::mesh_material::MeshMaterial3d<bevy_pbr::pbr_material::StandardMaterial>": (Path("materials/default.mat")),
+          "bevy_transform::components::transform::Transform": (
+            translation: (-2.0, 0.9711165, 0.0),
+            rotation: (0.0, 1.0, 0.0, -0.00000004371139),
+            scale: (1.0, 1.0, 1.0),
+          ),
+        },
+      ),
+      4294966397: (
+        components: {
+          "bevy_camera::visibility::Visibility": Inherited,
+          "bevy_ecs::hierarchy::ChildOf": (4294966398),
+          "bevy_ecs::hierarchy::Children": ([
+            4294966396,
+            4294966395,
+            4294966394,
+          ]),
+          "bevy_ecs::name::Name": "Solids",
+          "bevy_motiongfx::scene::id::EntityUid": ("59af9736-3ea8-49ad-adb2-88703abbf39d"),
+          "bevy_transform::components::transform::Transform": (
+            translation: (0.0, 1.2, 0.0),
+            rotation: (0.0, 0.0, 0.0, 1.0),
+            scale: (1.0, 1.0, 1.0),
+          ),
+        },
+      ),
+      4294966398: (
+        components: {
+          "bevy_camera::visibility::Visibility": Inherited,
+          "bevy_ecs::hierarchy::Children": ([
+            4294966397,
+            4294966393,
+          ]),
+          "bevy_transform::components::transform::Transform": (
+            translation: (0.0, 0.0, 0.0),
+            rotation: (0.0, 0.0, 0.0, 1.0),
+            scale: (1.0, 1.0, 1.0),
+          ),
+          "moxie::SceneRoot": (),
         },
       ),
     },
@@ -605,7 +605,7 @@
         ),
         Block(
           block: (
-            combinator: Chain,
+            combinator: All,
             children: [
               Action(
                 action: (

--- a/assets/projects/hello_world/hello_world.mox
+++ b/assets/projects/hello_world/hello_world.mox
@@ -605,7 +605,7 @@
         ),
         Block(
           block: (
-            combinator: Any,
+            combinator: Chain,
             children: [
               Action(
                 action: (

--- a/crates/motiongfx_scene/examples/dummy_scene.rs
+++ b/crates/motiongfx_scene/examples/dummy_scene.rs
@@ -44,6 +44,7 @@ fn main() {
                 duration: ms(600),
                 ease: Some(Ease::CubicEaseInOut),
                 interp: None,
+                name: None,
             }),
             Node::action(ActionCmd {
                 subject: 0,
@@ -53,6 +54,7 @@ fn main() {
                 duration: Duration::ZERO,
                 ease: None,
                 interp: None,
+                name: None,
             }),
         ]),
         values,

--- a/crates/motiongfx_scene/src/block.rs
+++ b/crates/motiongfx_scene/src/block.rs
@@ -4,6 +4,7 @@
 //! a [`Node`] is a nested block, an action leaf, or a delayed wrapper.
 //! Each maps 1:1 onto a `motiongfx` track combinator.
 
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::time::Duration;
 
@@ -24,6 +25,8 @@ use crate::refs::FieldRef;
 pub struct Block<B: SceneBackend> {
     pub combinator: Combinator,
     pub children: Vec<Node<B>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 impl<B: SceneBackend> Block<B> {
@@ -32,6 +35,7 @@ impl<B: SceneBackend> Block<B> {
         Self {
             combinator: Combinator::Chain,
             children,
+            name: None,
         }
     }
 }
@@ -113,4 +117,6 @@ pub struct ActionCmd<B: SceneBackend> {
     /// `None` = the field type's default interpolation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interp: Option<B::InterpId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }

--- a/crates/motiongfx_scene/src/block.rs
+++ b/crates/motiongfx_scene/src/block.rs
@@ -44,8 +44,6 @@ pub enum Combinator {
     Chain,
     /// Simultaneous; children share a start, wait for all. (`ord_all`)
     All,
-    /// Simultaneous; wait for any. (`ord_any`)
-    Any,
     /// Staggered starts, one `delay` apart. (`ord_flow`)
     Flow(Duration),
 }

--- a/crates/motiongfx_scene/src/compile.rs
+++ b/crates/motiongfx_scene/src/compile.rs
@@ -104,7 +104,6 @@ fn walk_block<B: SceneBackend>(
     let result = match block.combinator {
         Combinator::Chain => fragments.ord_chain(),
         Combinator::All => fragments.ord_all(),
-        Combinator::Any => fragments.ord_any(),
         Combinator::Flow(delay) => fragments.ord_flow(delay),
     };
 

--- a/crates/motiongfx_scene/tests/roundtrip.rs
+++ b/crates/motiongfx_scene/tests/roundtrip.rs
@@ -68,6 +68,7 @@ fn sample() -> Scene<RoundtripBackend> {
         duration: ms(500),
         ease: Some(Ease::CubicEaseInOut),
         interp: None,
+        name: None,
     };
 
     let animation = Block::chain(vec![
@@ -77,6 +78,7 @@ fn sample() -> Scene<RoundtripBackend> {
                 Node::action(action(1.0)),
                 Node::action(action(0.5)),
             ],
+            name: None,
         }),
         Node::action(action(2.0)).delay(ms(200)),
     ]);

--- a/crates/motiongfx_scene/tests/toy.rs
+++ b/crates/motiongfx_scene/tests/toy.rs
@@ -119,6 +119,7 @@ fn action_cmd(
         duration: ms(duration_ms),
         ease: None,
         interp: None,
+        name: None,
     }
 }
 
@@ -322,6 +323,7 @@ fn all_combinator_runs_children_simultaneously() {
                     200,
                 )),
             ],
+            name: None,
         },
         values,
     };
@@ -403,6 +405,7 @@ fn one_op_registration_covers_every_owning_type_sharing_t() {
         duration: ms(100),
         ease: None,
         interp: None,
+        name: None,
     };
     // Two owning types on one subject, so two initial entries.
     let mut staged = subject(&mut values, 0, &["x"]);

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -49,16 +49,13 @@ itself.
 deserializes with `None`, no migration needed (unlike `Any` above).
 
 - [x] `name: Option<String>` on `Block` and `ActionCmd`.
-- [x] Action panel: a Name row (reusing the registered `String`
-      `Inspect` widget, same as any other text field) heading the
-      panel, promoting into the bold heading once set; a muted,
-      not-bold "Unnamed" placeholder otherwise - `Label` has no italic
-      support today, so that part of the mock isn't literal. Both the
-      Name row and the heading read/write the same `Property`
-      (`Edit::Name`), so typing updates the heading live without a
-      panel rebuild - the same "identifier in `Shape`, live value read
-      through the widget's own binding" trick `Edit::Duration`/`Delay`
-      already use.
+- [x] Action panel: the heading itself is the editable Name field
+      (reusing the registered `String` `Inspect` widget, same as any
+      other text field) - no separate read-only title plus a Name row
+      beneath it; clicking the heading is what a text field already
+      does. Simpler than the mock's promote-on-set heading, and drops
+      needing a bold/muted or italic-placeholder distinction (`Label`
+      has no italic support today anyway).
 - [x] Timeline: a block's header shows its name if set, falling back
       to its combinator type (`block_layout::block_label`);
       `TimelineAction` grew an optional label child, pinned

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -1,0 +1,284 @@
+# Action editing
+
+Plan for the next round of timeline work: simpler block types, naming,
+collapsing, and a way to actually create an action from the editor -
+today nothing does; every `ActionCmd` in a scene comes from a
+hand-authored file. Mock: https://claude.ai/code/artifact/c8c57aa4-80dc-47b7-9971-6d8dd9c23d5f
+
+## Simplify `Combinator` to Chain / All / Flow
+
+`Combinator` keeps four variants today: `Chain`, `All`, `Any`,
+`Flow(Duration)`. `Any` is a genuinely different runtime primitive
+(`motiongfx::track::any()` takes the *min* duration - a race, not a
+wait-for-all), not foldable into anything else. `Flow`'s own duration
+math already generalizes `All`'s (stagger = 0 is `All`), so the two
+already sit close together conceptually, but they stay separate
+variants: the action panel picks between exactly three types (a radio,
+not a toggle on `All`), matching what the format already looks like
+once `Any` is gone.
+
+`Any` is real, existing asset files use it; those files are hand-edited
+directly rather than adding load-time migration logic to the format
+itself.
+
+- [x] Delete `Combinator::Any`. Fixed every now-non-exhaustive match:
+      `motiongfx_scene::compile.rs` (`ord_*` dispatch), `moxie/block_layout.rs`
+      (label, duration, lane assignment, plus the now-dead
+      `visual_end`/overlap-detection machinery `Any`'s asymmetric
+      timing needed, removed along with it), `moxie/ui/action.rs`
+      (`combinator_name`).
+- [x] `hello_world.mox`'s one `Any` block edited to `Chain` directly.
+      No other `.mox`/`.mgx.ron` asset uses it.
+- [ ] Action panel: replace the read-only "Combinator" row with a
+      3-way segmented control (Chain / All / Flow), feathers'
+      `RoundedCorners`/`ButtonVariant::Primary` pattern - selected
+      segment filled solid, no border, 1px gap as the seam between
+      segments, not a divider line. Picking Flow reveals its stagger
+      field the same way Delay already appears conditionally.
+
+## Name blocks and actions
+
+`Block` and `ActionCmd` have no name field today. Adding
+`name: Option<String>` to both, `#[serde(default, skip_serializing_if
+= "Option::is_none")]`, is purely additive - an old scene file just
+deserializes with `None`, no migration needed (unlike `Any` above).
+
+- [ ] `name: Option<String>` on `Block` and `ActionCmd`.
+- [ ] Action panel: a Name row heading the panel, promoting into the
+      bold heading once set; an italic "Unnamed" placeholder
+      otherwise.
+- [ ] Timeline: a block's header shows its name if set, falling back
+      to its combinator type; a wide-enough action bar shows its name
+      too.
+
+## Collapsible blocks
+
+Reuses `moxie_ui::fold::Foldable` - the same chevron/rail the entity
+inspector's own sections already use, not a new mechanism.
+
+- [ ] `TimelineBlock` gets a chevron (`fold::CHEVRON_SHUT`/`CHEVRON_OPEN`
+      convention) that toggles a folded state per block.
+- [ ] Collapsed: children hidden, header strip alone still spans the
+      block's full duration and shows its name - same as a collapsed
+      folder track in any NLE.
+
+## Unassigned actions (`Node::Draft`)
+
+A third `Node` variant, not `Option` fields on `ActionCmd` - keeping
+`ActionCmd` fully required everywhere it's already assumed to be
+(compile.rs, the registry's typed resolvers, `subject_of`/`field_name`)
+and putting "not yet specified" in the tree shape instead.
+
+```rust
+Node::Draft {
+    delay: Option<Duration>,
+    duration: Duration,
+    name: Option<String>,
+}
+```
+
+Living in the tree from creation means every mechanic already built
+around "a `Node` at a `path`" - selection, drag-to-merge/chain/out,
+naming, a parent block's collapse - applies to a draft with no extra
+plumbing. The alternative (an editor-only staging list outside
+`scene.0.animation`) would need its own parallel selection, placement,
+and timing concept instead of reusing what's there.
+
+- [ ] `Node::Draft` variant. New match arm everywhere `Node` is
+      matched exhaustively: `walk_node` (compile.rs), `measure_node`
+      (block_layout.rs), `node_at`/`node_at_mut`/`summarize`/
+      `Property::get`/`set` (action.rs).
+- [ ] `compile()`: a draft resolves to an empty/no-op `TrackFragment`
+      of its own duration - reserves its timing slot without needing
+      anything else resolved. Not a `CompileError`; being incomplete
+      isn't being broken.
+- [ ] Action panel: a draft's Subject/Field rows are pickers, not
+      display text.
+
+### Graduating: draft to action
+
+Not an ECS hook - `Node::Draft` lives in plain scene data
+(`EditorScene`), not entities/components, so there's nothing for a
+Bevy observer to react to. It's a plain check in the same write-back
+path `Property::set` already uses: whenever a picker writes subject or
+field, check whether *both* are now set, and if so, replace the
+`Node::Draft` at that path with a real `Node::Action` via
+`node_at_mut` (same helper `Property::set` already calls).
+
+- [ ] `op` defaults to `AnimOp::To` (the only variant that exists
+      today).
+- [ ] `value` (the *target*, not a starting point - `AnimOp::To`'s own
+      op closure ignores `_prev`) defaults to the field's current live
+      value, captured through the same reflect read `Property`/`Field`
+      already do. Allocate a new pool `Uuid`, insert into
+      `scene.0.values`'s matching typed column.
+- [ ] Open question: fire automatically the instant both are set, or
+      require an explicit confirm? Field-picking is a multi-click
+      drill into a reflected type tree, so an intermediate click
+      landing on a field before the user's done browsing could
+      prematurely graduate and capture the wrong value. Superseded in
+      practice by drag-to-create below, where subject+field arrive
+      together in one gesture - worth revisiting whether this path is
+      still needed at all once that ships.
+
+### Demoting: action back to draft
+
+The reverse direction. `CompileError::UnknownSubject` already exists
+because today, deleting an entity an action targets hard-fails
+`compile()` for the *whole scene* - `walk_block` unwinds through `?`
+at every level, no per-action recovery, and `recompile_dirty_scene`
+calls `.compile()` with `.expect(...)`, so this currently panics the
+editor, not just fails cleanly. Demoting the orphaned action to a
+draft instead turns "the whole scene stops compiling" into "one action
+needs reassignment."
+
+Two different triggers, two different demotion shapes:
+
+- [ ] Entity deleted: subject itself is gone, so nothing about the
+      action is still valid. Extend the existing `on_remove_entity_uid`
+      observer (`bevy_motiongfx/scene/id.rs`, already keeps
+      `SceneUidMap` in sync on `On<Remove, EntityUid>`) to also walk
+      `scene.0.animation` and demote every `Node::Action` whose
+      subject matches - full demotion, clear subject/field/op/value,
+      keep duration and any name.
+- [ ] Component removed, entity still alive: only the field is
+      dangling. Partial demotion - keep subject, clear field/op/value,
+      so the user only re-picks a field on the same entity. No single
+      generic "a component was removed" event exists in Bevy for
+      arbitrary types; this wants a validation pass over the tree's
+      real actions (resolve each `FieldRef`'s type-name to a `TypeId`
+      via `AppTypeRegistry::get_with_type_path`, same lookup
+      `field_name` already does, and check the subject still has it)
+      run when relevant things change, not one elegant observer.
+- [ ] There's no undo system in this editor at all. Auto-demoting on
+      delete is a silent, non-reversible rewrite of every action
+      touching that entity. Worth a confirmation prompt on deletion
+      when it would orphan live actions, even without full undo.
+
+## Moving and resizing in the timeline
+
+There's no stored "start time" anywhere in the data model - every
+position in `block_layout.rs` is computed from the tree (combinator +
+duration of preceding siblings + `delay`). The only knob that actually
+exists to drag is `delay`, already the existing Delay edit row, and
+what dragging means with it depends on the parent:
+
+- Inside a `Chain`, siblings are already sequential - giving one a
+  `delay` only opens a gap before it, it can't move past a neighbor.
+  Dragging past a sibling here means reordering `children`, not tuning
+  `delay`. Exact precedent already in the codebase:
+  `hierarchy/drag.rs`'s before/after drop-target pattern (used for
+  reparenting subjects) is the same "which list, and where in it"
+  problem, just applied to `Block.children`.
+- Inside `All`/`Flow`, or a block's own position in its parent,
+  dragging maps directly onto editing `delay`.
+
+Duration is asymmetric between actions and blocks:
+
+- An action's `duration` is a plain stored field, already editable via
+  the panel's Duration row. Dragging its right edge to resize is the
+  same edit, just via drag instead of typing a number.
+- A block's duration isn't stored at all - `block_duration()` derives
+  it from its children. A block has no edge to resize; only its body
+  is draggable (a move, via `delay`, same as any other node). Resizing
+  a block would mean time-stretching every child's duration/delay
+  proportionally - not in scope.
+
+Unifies with the merge/chain/drag-out design already mocked, rather
+than adding a fourth separate mechanic: drag an action's edge = resize
+(the only edge-drag there is); drag any node's body and release in
+open space = move (`delay` edit, or a `children` reorder inside a
+`Chain`); drag a body and release on/near another action = merge or
+chain, as already designed. Same `Dragging`-style resource, same
+ghost-preview visuals, one gesture vocabulary.
+
+- [ ] Edge-drag resize on `TimelineAction` only - `TimelineBlock` gets
+      no resize handle, body-drag only.
+- [ ] Body-drag move, both `TimelineAction` and `TimelineBlock`: edits
+      `delay` inside `All`/`Flow`/at a block's own position; reorders
+      `children` inside a `Chain`, reusing `hierarchy/drag.rs`'s
+      before/after drop-target pattern.
+
+## Creating an action: drag a field onto the timeline
+
+Better than draft-then-assign for the common case: drag a field row
+straight out of the Component Inspector onto the timeline. Subject
+(whatever entity is inspected) and field (the row dragged) arrive
+together in one gesture - this *is* the graduation moment, condensed,
+so for this path there's no draft phase at all. `Node::Draft` becomes
+purely what demotion produces, not something manually created for
+this flow; a manual "blank slot" affordance (block out timing before
+deciding what to animate) may still be worth keeping alongside this -
+open question.
+
+- [ ] Field eligibility (animatable, not just inspectable) decided at
+      row-*build* time, not drag-time: an ineligible field gets no
+      drag handle at all, not a refusal on drop. `moxie_ui`'s
+      `EntityInspector`/field-row builder has never known about
+      `SceneRegistry` and shouldn't start now (same boundary as the
+      rest of this session's reuse work) - the eligibility check and
+      the drag-start wiring both live in `moxie`, layered onto the
+      field rows `EntityInspector` already builds, not inside
+      `moxie_ui`'s generic `Inspect` widget system.
+- [ ] `SceneRegistry` needs a new read method - it currently only has
+      `register_*`, no way to ask "is this `FieldRef` registered."
+- [ ] Per-axis dragging for vector fields. `inspector/vector.rs`'s
+      `axes()` renders x/y/z as one combined `Inspect` leaf today, on
+      purpose, for editing ("the widget needs no way to address an
+      axis on its own"). The scene format already supports a sub-path
+      like `"translation::x"` (see `refs.rs`, `roundtrip.rs`) - the
+      gap is only the widget. Give each of the three number inputs
+      its own drag-start handle, composing the base path with
+      `::x`/`::y`/`::z`.
+- [ ] Cross-panel drag reuses the pattern `hierarchy/drag.rs` already
+      establishes: a `Resource` tracking what's held and where it'd
+      land, driven by Bevy's own `Pointer<DragStart/Drag/DragOver/
+      DragDrop/DragEnd>` events, which fire on whatever's under the
+      cursor regardless of which panel it's in. Needs a parallel
+      resource (or a generalized one) with drop-target observers added
+      to the timeline's scene area.
+- [ ] Live ghost during the drag: reuses the exact visuals already
+      built for action-to-action dragging (dashed accent border,
+      reduced opacity) rather than new vocabulary. The timeline's
+      `DragOver` handler computes the prospective start time from the
+      pointer's x (inverse of `px_for`) and draws the ghost there,
+      sized to a default duration.
+- [ ] Dropping onto/near an existing action should trigger the same
+      merge-into-All / snap-into-Chain restructuring already designed
+      for action-to-action dragging, rather than a separate drop path.
+      Open question: should a drop also be allowed to land anywhere on
+      empty timeline space, or only inside an existing block / on an
+      existing action?
+- [ ] On drop: `op` defaults to `AnimOp::To`, `value` captured from
+      the field's live value at drag-start (same capture as
+      graduation), duration defaults to some fixed constant until
+      there's a reason to make it drag-configurable.
+
+## Editing the stage
+
+The stage (`Scene::stage`, `Subject.fields: Vec<FieldSeed>`) is not an
+action's own value - `AnimOp::To`'s op closure ignores `_prev`
+entirely, so an action only ever carries its *target*. The stage is
+specifically the starting point for the *first* action on a field with
+no predecessor; later actions in a chain inherit the previous action's
+target instead. Nothing edits the stage today - grepped the whole
+editor, `Stage`/`FieldSeed` are read-only, at one `.stage()` call site.
+
+- [ ] A toggle on the Component Inspector's own field rows, to pin the
+      field's current live value as its stage seed. Doesn't require an
+      action to exist first, which matters - a field can want a
+      specific starting pose before anything animates it yet.
+- [ ] A companion row in the action panel, shown only when the
+      selected action is the earliest one touching that subject+field
+      (needs `summarize()` to find that by walking the tree in time
+      order) - so editing an action's timing doesn't require leaving
+      the panel to see what it starts from.
+
+## Explicitly backlogged, not part of this round
+
+- [ ] Incremental names for newly created entities ("Cube", "Cube 1",
+      "Cube 2", ...).
+- [ ] The Operation row: `AnimOp` has exactly one variant (`To`) today,
+      so it stays a plain hidden/read-only row rather than a variant
+      picker (the same `VariantPicker` pattern Ease/Interp already
+      use) until a second op actually exists.

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -37,9 +37,9 @@ itself.
       `ButtonElem`/`SegmentButton`, mirroring bevy_feathers'
       `RoundedCorners`/`ButtonVariant::Primary` pattern: selected
       segment filled solid, no border, 1px gap as the seam between
-      segments (the row clips its children rather than rounding each
-      segment). Picking Flow still reveals its stagger field the same
-      way Delay already appears conditionally.
+      segments, only the row's own two ends rounded (not themed yet -
+      see `docs/backlog.md`). Picking Flow still reveals its stagger
+      field the same way Delay already appears conditionally.
 
 ## Name blocks and actions
 

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -48,13 +48,22 @@ itself.
 = "Option::is_none")]`, is purely additive - an old scene file just
 deserializes with `None`, no migration needed (unlike `Any` above).
 
-- [ ] `name: Option<String>` on `Block` and `ActionCmd`.
-- [ ] Action panel: a Name row heading the panel, promoting into the
-      bold heading once set; an italic "Unnamed" placeholder
-      otherwise.
-- [ ] Timeline: a block's header shows its name if set, falling back
-      to its combinator type; a wide-enough action bar shows its name
-      too.
+- [x] `name: Option<String>` on `Block` and `ActionCmd`.
+- [x] Action panel: a Name row (reusing the registered `String`
+      `Inspect` widget, same as any other text field) heading the
+      panel, promoting into the bold heading once set; a muted,
+      not-bold "Unnamed" placeholder otherwise - `Label` has no italic
+      support today, so that part of the mock isn't literal. Both the
+      Name row and the heading read/write the same `Property`
+      (`Edit::Name`), so typing updates the heading live without a
+      panel rebuild - the same "identifier in `Shape`, live value read
+      through the widget's own binding" trick `Edit::Duration`/`Delay`
+      already use.
+- [x] Timeline: a block's header shows its name if set, falling back
+      to its combinator type (`block_layout::block_label`);
+      `TimelineAction` grew an optional label child, pinned
+      top-left and clipped, so a bar too narrow for its name just
+      shows nothing instead of overflowing its neighbor.
 
 ## Collapsible blocks
 

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -29,12 +29,17 @@ itself.
       (`combinator_name`).
 - [x] `hello_world.mox`'s one `Any` block edited to `Chain` directly.
       No other `.mox`/`.mgx.ron` asset uses it.
-- [ ] Action panel: replace the read-only "Combinator" row with a
-      3-way segmented control (Chain / All / Flow), feathers'
-      `RoundedCorners`/`ButtonVariant::Primary` pattern - selected
+- [x] Action panel: replaced the read-only "Combinator" row (and the
+      "Children" row next to it, dropped as clutter) with a `Type`
+      row holding a 3-way segmented control (Chain / All / Flow) -
+      `moxie_ui::elements::SegmentedControl`, a reusable composer, not
+      wired to anything scene-specific itself. Styled on
+      `ButtonElem`/`SegmentButton`, mirroring bevy_feathers'
+      `RoundedCorners`/`ButtonVariant::Primary` pattern: selected
       segment filled solid, no border, 1px gap as the seam between
-      segments, not a divider line. Picking Flow reveals its stagger
-      field the same way Delay already appears conditionally.
+      segments (the row clips its children rather than rounding each
+      segment). Picking Flow still reveals its stagger field the same
+      way Delay already appears conditionally.
 
 ## Name blocks and actions
 

--- a/editor/docs/backlog.md
+++ b/editor/docs/backlog.md
@@ -185,3 +185,141 @@ embed-or-reference flag, or Rive's embed-by-default. Not Bevy's own
       `.mat`.
 - [ ] A preview panel beside the asset browser's own listing, showing
       whatever asset is currently selected or hovered there.
+
+## Treat multi-item files (`.glb` and similar) as folders in the asset panel
+
+The asset panel (`editor/moxie/src/ui/assets.rs`) already has a folder
+concept, but only for real filesystem directories: `FolderRow` /
+`BookmarkRow` both lean on `moxie_ui::fold::Foldable` and a live
+`fs::read_dir` (`build_children`) to expand a directory into its
+children, tracked open/closed by `AssetFoldState`. What decides
+whether a *file* is even recognized is `moxie_asset::AssetKinds`, a
+flat `extension -> TypeId` map with exactly one registration today
+(`.mat` -> `StandardMaterial`, in `inspector.rs`); nothing maps `.glb`/
+`.gltf`, so such a file currently renders inert and undraggable.
+
+A `.glb` isn't a single asset the way a `.mat` is - it's a small
+archive (meshes, materials, lights, cameras, an implicit scene graph).
+Making it *browsable* as a folder means the row needs to expand into a
+synthetic child list the same way `FolderRow` does, but sourced from
+gltf-parsed contents instead of `fs::read_dir`. That's a second, virtual
+kind of expandable row alongside the filesystem-backed one -
+`FolderRow`'s body-building step (`build_children`) would need a
+non-filesystem counterpart that inspects a `Gltf`/`GltfAssetLabel`'s
+node list instead of walking a path, while still fitting the same
+`Foldable` shell and `AssetFoldState` bookkeeping. No `Gltf`/
+`GltfAssetLabel`/`SceneRoot`-from-`bevy::scene` usage exists anywhere
+in `editor/` yet - this is greenfield relative to the current asset
+loading code. Worth noting: the editor already has its own unrelated
+`SceneRoot` marker (`editor/moxie/src/lib.rs`) naming the scene tree's
+own root entity - a real gltf `SceneRoot` component would need a
+distinguishing name or an explicit path (`bevy::scene::SceneRoot`)
+wherever both are in scope.
+
+Each child item (a mesh, a material, a light) still wants its own
+`AssetKinds` entry so it can be dragged into a `Handle<T>` field the
+same way a `.mat` can be today - a gltf-derived material handle isn't
+structurally different from a hand-authored one once loaded.
+
+- [ ] Register `.glb`/`.gltf` extensions against `bevy_gltf::Gltf` (or
+      per-sub-asset types) in `AssetKinds`, so the file stops being
+      inert in the browser.
+- [ ] A "virtual folder" row variant that expands via a gltf's parsed
+      node/mesh/material list instead of `fs::read_dir`, reusing
+      `Foldable`/`AssetFoldState` rather than forking them.
+- [ ] Decide the child-item addressing scheme (bevy's own
+      `GltfAssetLabel` path syntax, e.g. `Mesh0/Primitive0`, is the
+      obvious fit) so a child row's path round-trips through
+      `AssetServer::load`.
+- [ ] Wire each recognized child kind (`Handle<Mesh>`,
+      `Handle<StandardMaterial>`, lights) into `draggable(...)` the
+      same way `file_row` already does for flat files.
+- [ ] Generalize past `.glb` specifically once the pattern holds -
+      any future container format (e.g. a multi-clip animation file)
+      wants the same virtual-folder shell, not a bespoke one per format.
+
+## Drag a `.glb` straight into the hierarchy to spawn its scene
+
+Two unrelated drag systems exist today, and neither reaches across to
+the other. `editor/moxie/src/ui/hierarchy/drag.rs`'s `Dragging`
+resource only reacts to other hierarchy rows (reparent/reorder within
+the tree). `editor/moxie_ui/src/asset.rs`'s `AssetDragging` resource -
+structurally the same ghost-follows-cursor pattern, for files instead
+of rows - is only ever *read* by one consumer:
+`editor/moxie_ui/src/inspector/handle.rs`'s `Inspect for Handle<T>`,
+which compares `AssetDragging.kind` against the inspected field's
+`TypeId` and loads a `Handle<T>` onto that field on drop. Dropping a
+file over the hierarchy panel today does nothing - nothing there reads
+`AssetDragging` at all.
+
+Spawning a `.glb`'s scene into the hierarchy needs a new drop target
+that *does* read `AssetDragging`, added to the hierarchy panel (rows
+and/or the gap strip in `editor/moxie/src/ui/hierarchy.rs`), mirroring
+`Inspect for Handle<T>`'s drop-handling shape but building
+`bevy::scene::SceneRoot`/child entities from the gltf's default scene
+instead of writing a single field. This is a natural companion to the
+folder-browsing item above (same `.glb` registration work), but is
+useful on its own even before individual gltf children are browsable -
+dropping the whole file can just spawn the default scene.
+
+- [ ] A hierarchy-panel drop target reading `AssetDragging`,
+      alongside the existing entity-reparenting one in
+      `hierarchy/drag.rs` - same resource, different consumer.
+- [ ] On drop, resolve the dragged path to a gltf asset and spawn its
+      default scene (or the whole node graph) as children of the drop
+      target, parallel to how `Inspect for Handle<T>` resolves a path
+      through `AssetServer` with `override_unapproved()` today.
+- [ ] Decide undo/naming conventions for a spawned subtree - it's the
+      first hierarchy mutation that isn't either hand-built in the
+      editor or loaded wholesale from a `.mox`.
+
+## Multiple simultaneous tracks in the timeline
+
+"Multiple tracks" already exists at two different layers, and neither
+is a video-editor-style stack a user can freely add to:
+
+- **Runtime** (`crates/motiongfx/src/track.rs`,`timeline.rs`):
+  `TrackList`/`Timeline` do hold `Box<[Track]>`, but `curr_index`/
+  `target_index` and `set_target_track` describe *switching between*
+  tracks (jump to another sequence and play toward/from it), not
+  sampling several simultaneously. Repurposing this for layered
+  playback would change `queue_actions`'s sampling model, not just add
+  UI.
+- **Editor UI** (`motiongfx_scene::block::Block`/`Combinator`,
+  `editor/moxie/src/block_layout.rs`): `Scene::animation` is one
+  `Block` tree; "tracks" only appear as the lanes `block_layout::layout`
+  already assigns per sibling under `All`/`Any`/`Flow` - every child of
+  one of those combinators gets its own row today
+  (`measure_children`), stacked and drawn by `ui/timeline.rs`'s
+  `TrackArea`. There's no persistent, user-named, independently
+  addable "Track 1 / Track 2" the way a video editor has - what looks
+  like stacked lanes is really nested combinator structure, laid out
+  automatically.
+
+The second point matters for scoping: a literal free-form track list
+(add/remove/reorder independent tracks a user names) means either
+changing `Scene`'s schema to hold a flat `Vec<Block>` alongside/instead
+of the single `animation` root - touching serialization,
+`block_layout.rs`, and every `EditorScene` mutator - or leaning on the
+`All`/`Flow` nesting that already lays siblings out as lanes and
+building add/remove/reorder affordances directly on top of that
+existing behavior. The latter is a much smaller lift since the layout
+half is already built; it would mainly need UI to let a user insert/
+remove a top-level `All` child and treat it as a named lane, rather
+than requiring the tree-editing gestures the timeline doesn't expose
+today.
+
+- [ ] Decide the schema question first: reuse `All`/`Flow` top-level
+      children as lanes, or give `Scene` an explicit flat track list -
+      this determines the size of everything else.
+- [ ] If reusing combinator nesting: UI affordances on the timeline
+      panel to add/remove/reorder a top-level lane (today's tree has
+      no user-facing "insert a sibling block" gesture at all).
+- [ ] Lane naming/labeling - `block_layout.rs`'s `combinator_label`
+      shows the `Combinator` kind, not a user-chosen name; a track
+      stack wants the latter.
+- [ ] If simultaneous (not switched) playback is ever needed at
+      runtime, not just visually stacked in the editor: revisit
+      `Timeline`'s `curr_index`/`target_index` sampling model in
+      `crates/motiongfx/src/timeline.rs`, which currently assumes one
+      active track at a time.

--- a/editor/docs/backlog.md
+++ b/editor/docs/backlog.md
@@ -20,6 +20,10 @@ those as moxie_ui elements styled off `EditorTheme`, then drop
       them.
 - [ ] `Label`'s `None => ThemedText` fallback should default to
       `theme.text_primary` directly.
+- [ ] Give `EditorTheme` a button corner radius (there's no field for
+      one today) and use it everywhere a button rounds itself -
+      `Button`/`GhostButton`/`MenuButton`/`SegmentButton` each pick
+      their own `px(N)` constant right now.
 
 ## Open a `.mox` by double-clicking it
 

--- a/editor/moxie/src/block_layout.rs
+++ b/editor/moxie/src/block_layout.rs
@@ -126,14 +126,12 @@ fn measure_node(node: &Node<Backend>, start: Duration) -> Measured {
     let start = start.saturating_add(delay);
 
     match node {
-        Node::Action { action, .. } => {
-            Measured {
-                start,
-                end: start.saturating_add(action.duration),
-                height: ROW_HEIGHT,
-                kind: MeasuredKind::Action,
-            }
-        }
+        Node::Action { action, .. } => Measured {
+            start,
+            end: start.saturating_add(action.duration),
+            height: ROW_HEIGHT,
+            kind: MeasuredKind::Action,
+        },
         Node::Block { block, .. } => measure_block(block, start),
     }
 }

--- a/editor/moxie/src/block_layout.rs
+++ b/editor/moxie/src/block_layout.rs
@@ -52,17 +52,8 @@ pub(crate) fn layout(animation: &Block<Backend>) -> Vec<Placed> {
 struct Measured {
     start: Duration,
     /// This node's own duration - `node_duration`/`block_duration` -
-    /// what its *own* box is drawn to. A block's box is only ever
-    /// this wide, `Any` included: it marks the group's boundary, not
-    /// how long its content happens to keep drawing past it.
+    /// what its box is drawn to.
     end: Duration,
-    /// The rightmost point any of this node's own content actually
-    /// draws to - used only to detect whether a following `Chain`
-    /// sibling needs to drop to a new row, never to size a box. Equal
-    /// to `end` everywhere except an `Any`, whose losing branch keeps
-    /// animating (and drawing) past it, and any block containing one,
-    /// recursively.
-    visual_end: Duration,
     height: f32,
     kind: MeasuredKind,
 }
@@ -79,7 +70,6 @@ fn combinator_label(combinator: &Combinator) -> String {
     match combinator {
         Combinator::Chain => "Chain".into(),
         Combinator::All => "All".into(),
-        Combinator::Any => "Any".into(),
         Combinator::Flow(delay) => {
             format!("Flow {:.2}s", delay.as_secs_f32())
         }
@@ -113,10 +103,6 @@ fn block_duration(block: &Block<Backend>) -> Duration {
             { block.children.iter().map(node_duration).max() }
                 .unwrap_or_default()
         }
-        Combinator::Any => {
-            { block.children.iter().map(node_duration).min() }
-                .unwrap_or_default()
-        }
         Combinator::Flow(delay) => block
             .children
             .iter()
@@ -141,11 +127,9 @@ fn measure_node(node: &Node<Backend>, start: Duration) -> Measured {
 
     match node {
         Node::Action { action, .. } => {
-            let end = start.saturating_add(action.duration);
             Measured {
                 start,
-                end,
-                visual_end: end,
+                end: start.saturating_add(action.duration),
                 height: ROW_HEIGHT,
                 kind: MeasuredKind::Action,
             }
@@ -160,15 +144,9 @@ fn measure_block(
 ) -> Measured {
     let (children, content_height) =
         measure_children(&block.children, &block.combinator, start);
-    let visual_end = children
-        .iter()
-        .map(|(_, m)| m.visual_end)
-        .max()
-        .unwrap_or(start);
     Measured {
         start,
         end: start.saturating_add(block_duration(block)),
-        visual_end,
         height: HEADER_HEIGHT + content_height,
         kind: MeasuredKind::Block {
             label: combinator_label(&block.combinator),
@@ -179,20 +157,14 @@ fn measure_block(
 
 /// Measures every child, then lays them into lanes (rows).
 ///
-/// `All`/`Any`/`Flow` give each child its own dedicated lane, always -
+/// `All`/`Flow` give each child its own dedicated lane, always -
 /// packing them would occasionally let two children share a lane (a
 /// `Flow`'s first and fifth child, say, once the first has finished),
 /// which reads as one fused bar instead of two separate actions.
 ///
-/// A `Chain`'s children share one row by default, since they never
-/// overlap by construction - except an `Any` child's visual extent
-/// can bleed past its official contribution to the chain (its losing
-/// branch keeps animating), reaching into where the next sibling
-/// starts. When it does, only *that* sibling drops below - directly
-/// under the one predecessor it actually overlaps, not under whatever
-/// else happens to share the row - since a chain's children are
-/// already time-ordered and only ever need to check the one right
-/// before them.
+/// A `Chain`'s children share one row, since they never overlap by
+/// construction: each one starts only once its predecessor's duration
+/// (plus its own `delay`) has elapsed.
 fn measure_children(
     children: &[Node<Backend>],
     combinator: &Combinator,
@@ -214,7 +186,7 @@ fn measure_children(
                 })
                 .collect()
         }
-        Combinator::All | Combinator::Any => {
+        Combinator::All => {
             children.iter().map(|_| block_start).collect()
         }
         Combinator::Flow(delay) => (0..children.len())
@@ -232,24 +204,12 @@ fn measure_children(
         .collect();
 
     let ys: Vec<f32> = match combinator {
-        Combinator::Chain => {
-            let mut ys = Vec::with_capacity(measured.len());
-            let mut prev: Option<(Duration, f32, f32)> = None;
-            for m in &measured {
-                let y = match prev {
-                    Some((end, y, height)) if m.start < end => {
-                        y + height + LANE_GAP
-                    }
-                    _ => 0.0,
-                };
-                ys.push(y);
-                prev = Some((m.visual_end, y, m.height));
-            }
-            ys
-        }
-        // Every other combinator's children can genuinely overlap in
-        // time, so each always gets its own dedicated row.
-        Combinator::All | Combinator::Any | Combinator::Flow(_) => {
+        // Children never overlap in time by construction, so they all
+        // share one row.
+        Combinator::Chain => vec![0.0; measured.len()],
+        // `All`/`Flow` children can genuinely overlap in time, so each
+        // always gets its own dedicated row.
+        Combinator::All | Combinator::Flow(_) => {
             let mut y = 0.0;
             measured
                 .iter()

--- a/editor/moxie/src/block_layout.rs
+++ b/editor/moxie/src/block_layout.rs
@@ -20,8 +20,8 @@ const HEADER_HEIGHT: f32 = 20.0;
 const LANE_GAP: f32 = 4.0;
 const MIN_WIDTH: f32 = 2.0;
 
-/// One box to draw: a block header (its combinator, as a label) or an
-/// action leaf.
+/// One box to draw: a block header (its name, or its combinator if
+/// unnamed) or an action leaf.
 #[derive(Clone, PartialEq)]
 pub(crate) struct Placed {
     pub(crate) x: f32,
@@ -31,6 +31,9 @@ pub(crate) struct Placed {
     pub(crate) depth: usize,
     /// `Some` for a block header box; `None` for an action leaf.
     pub(crate) label: Option<String>,
+    /// An action leaf's own name, if set. `None` for a block - its
+    /// name, if any, is already folded into `label`.
+    pub(crate) name: Option<String>,
     /// This node's position in `animation`'s tree: child index at
     /// each depth, root first. What [`crate::SelectedAction`] compares
     /// against, so a click can name exactly which node it landed on.
@@ -59,11 +62,22 @@ struct Measured {
 }
 
 enum MeasuredKind {
-    Action,
+    Action {
+        name: Option<String>,
+    },
     Block {
         label: String,
         children: Vec<(f32, Measured)>,
     },
+}
+
+/// A block's own header text: its name if set, its combinator
+/// otherwise.
+fn block_label(block: &Block<Backend>) -> String {
+    block
+        .name
+        .clone()
+        .unwrap_or_else(|| combinator_label(&block.combinator))
 }
 
 fn combinator_label(combinator: &Combinator) -> String {
@@ -130,7 +144,9 @@ fn measure_node(node: &Node<Backend>, start: Duration) -> Measured {
             start,
             end: start.saturating_add(action.duration),
             height: ROW_HEIGHT,
-            kind: MeasuredKind::Action,
+            kind: MeasuredKind::Action {
+                name: action.name.clone(),
+            },
         },
         Node::Block { block, .. } => measure_block(block, start),
     }
@@ -147,7 +163,7 @@ fn measure_block(
         end: start.saturating_add(block_duration(block)),
         height: HEADER_HEIGHT + content_height,
         kind: MeasuredKind::Block {
-            label: combinator_label(&block.combinator),
+            label: block_label(block),
             children,
         },
     }
@@ -243,13 +259,14 @@ fn flatten(
             .max(MIN_WIDTH);
 
     match &measured.kind {
-        MeasuredKind::Action => out.push(Placed {
+        MeasuredKind::Action { name } => out.push(Placed {
             x,
             y,
             w,
             h: measured.height,
             depth,
             label: None,
+            name: name.clone(),
             path: path.clone(),
         }),
         MeasuredKind::Block { label, children } => {
@@ -260,6 +277,7 @@ fn flatten(
                 h: measured.height,
                 depth,
                 label: Some(label.clone()),
+                name: None,
                 path: path.clone(),
             });
             let content_top = y + HEADER_HEIGHT;

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -18,7 +18,7 @@ use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
 use motiongfx_scene::block::{ActionCmd, Block, Combinator, Node};
 use motiongfx_scene::refs::FieldRef;
-use moxie_ui::elements::{Label, ScrollArea, display_name};
+use moxie_ui::elements::{Frame, Label, ScrollArea, display_name};
 use moxie_ui::inspector::{
     FieldRow, Source, inspect_value, reflect_changed,
 };
@@ -77,11 +77,24 @@ struct Shape {
     path: Option<Vec<usize>>,
     /// Empty when the path no longer lands on a node.
     kind: &'static str,
+    /// Set only for an action: a block has none to show.
+    subject: Option<Subject>,
     rows: Vec<(String, String)>,
     edits: Vec<(String, Edit)>,
     /// The action's target value. Which widget draws it is the
     /// registry's business, not this panel's.
     value: Option<Pooled>,
+}
+
+/// An action's subject, split so its id can render muted where its
+/// name cannot.
+#[derive(Clone, PartialEq)]
+struct Subject {
+    /// Its [`Name`], if it still has an entity.
+    name: Option<String>,
+    /// The head of its id - a whole uuid is unreadable, but two
+    /// entities sharing a name still need telling apart.
+    head: String,
 }
 
 /// The action's target value, wherever the pool keeps it.
@@ -107,6 +120,7 @@ fn shape(world: &World, _: Entity) -> Shape {
         .unwrap_or(Shape {
             path,
             kind: "",
+            subject: None,
             rows: Vec::new(),
             edits: Vec::new(),
             value: None,
@@ -127,6 +141,40 @@ fn build(ui: &mut BevyUi) {
     }
 
     heading(ui, theme, shape.kind);
+    if let Some(subject) = shape.subject {
+        let primary = theme.text_primary;
+        let muted = theme.text_muted;
+        ui.compose(FieldRow {
+            label: "Subject".to_string(),
+            color: muted,
+            bold: false,
+            depth: 0,
+            value: move |ui: &mut BevyUi| {
+                ui.elem(elem!(
+                    Frame,
+                    direction = FlexDirection::Row,
+                    align = AlignItems::Center,
+                    column_gap = px(4)
+                ))
+                .with(move |ui| {
+                    if let Some(name) = subject.name {
+                        ui.elem(elem!(
+                            Label,
+                            text = name,
+                            color = Some(primary),
+                            wrap = false
+                        ));
+                    }
+                    ui.elem(elem!(
+                        Label,
+                        text = format!("#{}", subject.head),
+                        color = Some(muted),
+                        wrap = false
+                    ));
+                });
+            },
+        });
+    }
     for (name, value) in shape.rows {
         let primary = theme.text_primary;
         ui.compose(FieldRow {
@@ -188,6 +236,7 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
             return Some(Shape {
                 path: Some(path.to_vec()),
                 kind: "Block",
+                subject: None,
                 value: None,
                 rows: vec![
                     (
@@ -216,9 +265,9 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
     Some(Shape {
         path: Some(path.to_vec()),
         kind: "Action",
+        subject: Some(subject_of(world, action)),
         value: Some(Pooled(action.value)),
         rows: vec![
-            ("Subject".into(), subject_name(world, action)),
             ("Field".into(), field_name(world, &action.field)),
             ("Operation".into(), format!("{:?}", action.op)),
         ],
@@ -413,22 +462,20 @@ fn set_seconds(node: &mut Node<Backend>, edit: Edit, value: f32) {
     }
 }
 
-/// Its [`Name`], if it still has an entity, followed by the head of
-/// its id - a whole uuid is unreadable, but two entities sharing a
-/// name still need telling apart.
-fn subject_name(world: &World, action: &ActionCmd<Backend>) -> String {
+/// The action's subject, as its own [`Name`] (if it still has an
+/// entity) and the head of its id.
+fn subject_of(world: &World, action: &ActionCmd<Backend>) -> Subject {
     let SceneUid::Entity(uid) = action.subject;
-    let head = hierarchy::uid_head(uid);
 
     let name = world
         .get_resource::<SceneUidMap>()
         .and_then(|map| map.entity(uid))
         .and_then(|entity| world.get::<Name>(entity))
-        .map(Name::as_str);
+        .map(|name| name.as_str().to_string());
 
-    match name {
-        Some(name) => format!("{name} #{head}"),
-        None => format!("#{head}"),
+    Subject {
+        name,
+        head: hierarchy::uid_head(uid),
     }
 }
 

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -553,7 +553,6 @@ fn combinator_name(combinator: &Combinator) -> &'static str {
     match combinator {
         Combinator::Chain => "Chain",
         Combinator::All => "All",
-        Combinator::Any => "Any",
         // Its stagger is editable, so the row above only names it.
         Combinator::Flow(_) => "Flow",
     }

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -149,7 +149,7 @@ fn build(ui: &mut BevyUi) {
         return;
     }
 
-    heading(ui, shape.kind, path.clone());
+    heading(ui, path.clone());
     {
         let source = Property {
             path: path.clone(),
@@ -684,10 +684,9 @@ fn combinator_name(combinator: &Combinator) -> &'static str {
 
 /// The panel's heading: the node's name if set (bold, primary text),
 /// or an "Unnamed" placeholder (muted, not bold) - the same promotion
-/// the Name row below reads and writes - plus a small tag naming its
-/// kind. Bound to the same `Name` edit, so it stays live as that row
-/// is typed into.
-fn heading(ui: &mut BevyUi, kind: &'static str, path: Vec<usize>) {
+/// the Name row below reads and writes. Bound to the same `Name`
+/// edit, so it stays live as that row is typed into.
+fn heading(ui: &mut BevyUi, path: Vec<usize>) {
     let primary = ui.theme.text_primary;
     let muted = ui.theme.text_muted;
 
@@ -698,51 +697,31 @@ fn heading(ui: &mut BevyUi, kind: &'static str, path: Vec<usize>) {
     let named = shown_name(&source, ui.world);
 
     ui.elem(elem!(
-        Frame,
-        direction = FlexDirection::Row,
-        align = AlignItems::Baseline,
-        column_gap = px(6)
+        Label,
+        text = named.clone().unwrap_or_else(|| "Unnamed".into()),
+        bold = named.is_some(),
+        color = Some(if named.is_some() { primary } else { muted })
     ))
-    .with(move |ui| {
-        ui.elem(elem!(
-            Label,
-            text = named.clone().unwrap_or_else(|| "Unnamed".into()),
-            bold = named.is_some(),
-            color =
-                Some(if named.is_some() { primary } else { muted })
-        ))
-        .bind(|label| label.text(), when_changed(&source), {
-            let source = source.boxed();
-            move |world, _| {
-                shown_name(&*source, world)
-                    .unwrap_or_else(|| "Unnamed".into())
+    .bind(|label| label.text(), when_changed(&source), {
+        let source = source.boxed();
+        move |world, _| {
+            shown_name(&*source, world)
+                .unwrap_or_else(|| "Unnamed".into())
+        }
+    })
+    .bind(|label| label.bold(), when_changed(&source), {
+        let source = source.boxed();
+        move |world, _| shown_name(&*source, world).is_some()
+    })
+    .bind(|label| label.color(), when_changed(&source), {
+        let source = source.boxed();
+        move |world, _| {
+            if shown_name(&*source, world).is_some() {
+                primary
+            } else {
+                muted
             }
-        })
-        .bind(|label| label.bold(), when_changed(&source), {
-            let source = source.boxed();
-            move |world, _| shown_name(&*source, world).is_some()
-        })
-        .bind(
-            |label| label.color(),
-            when_changed(&source),
-            {
-                let source = source.boxed();
-                move |world, _| {
-                    if shown_name(&*source, world).is_some() {
-                        primary
-                    } else {
-                        muted
-                    }
-                }
-            },
-        );
-
-        ui.elem(elem!(
-            Label,
-            text = kind.to_string(),
-            size = 10.0f32,
-            color = Some(muted)
-        ));
+        }
     });
 }
 

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -502,7 +502,7 @@ fn field_name(world: &World, field: &FieldRef) -> String {
                 .into()
         });
 
-    format!("{name}::{}", field.path())
+    format!("{name}{}", field.path())
 }
 
 fn combinator_name(combinator: &Combinator) -> &'static str {

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -219,38 +219,25 @@ fn build(ui: &mut BevyUi) {
 }
 
 /// The selected node, as what to show and what can be changed.
+///
+/// An empty `path` names the tree's own root - a block like any
+/// other, just never wrapped in a [`Node`] of its own, so it has no
+/// delay to show or edit.
 fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
     let scene = world.get_resource::<EditorScene>()?.scene();
-    let node = node_at(&scene.0.animation, path)?;
 
+    if path.is_empty() {
+        return Some(block_shape(
+            Vec::new(),
+            &scene.0.animation,
+            None,
+        ));
+    }
+
+    let node = node_at(&scene.0.animation, path)?;
     let (delay, action) = match node {
         Node::Block { block, delay } => {
-            let mut edits = Vec::new();
-            if matches!(block.combinator, Combinator::Flow(_)) {
-                edits.push(("Stagger".to_string(), Edit::Stagger));
-            }
-            if delay.is_some() {
-                edits.push(("Delay".to_string(), Edit::Delay));
-            }
-
-            return Some(Shape {
-                path: Some(path.to_vec()),
-                kind: "Block",
-                subject: None,
-                value: None,
-                rows: vec![
-                    (
-                        "Combinator".into(),
-                        combinator_name(&block.combinator)
-                            .to_string(),
-                    ),
-                    (
-                        "Children".into(),
-                        block.children.len().to_string(),
-                    ),
-                ],
-                edits,
-            });
+            return Some(block_shape(path.to_vec(), block, *delay));
         }
         Node::Action { action, delay } => (delay, action),
     };
@@ -273,6 +260,38 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
         ],
         edits,
     })
+}
+
+/// A block's own row of info: its combinator and child count, plus
+/// whatever of its timing the [`Node`] wrapping it (if any) lets
+/// through.
+fn block_shape(
+    path: Vec<usize>,
+    block: &Block<Backend>,
+    delay: Option<Duration>,
+) -> Shape {
+    let mut edits = Vec::new();
+    if matches!(block.combinator, Combinator::Flow(_)) {
+        edits.push(("Stagger".to_string(), Edit::Stagger));
+    }
+    if delay.is_some() {
+        edits.push(("Delay".to_string(), Edit::Delay));
+    }
+
+    Shape {
+        path: Some(path),
+        kind: "Block",
+        subject: None,
+        value: None,
+        rows: vec![
+            (
+                "Combinator".into(),
+                combinator_name(&block.combinator).to_string(),
+            ),
+            ("Children".into(), block.children.len().to_string()),
+        ],
+        edits,
+    }
 }
 
 /// The node `path` names.
@@ -367,6 +386,13 @@ impl Source for Pooled {
 impl Source for Property {
     fn get(&self, world: &World) -> Option<Box<dyn PartialReflect>> {
         let scene = world.get_resource::<EditorScene>()?.scene();
+
+        // The root has no `Node` of its own, so no `Ease`, `Interp`,
+        // `Duration` or `Delay` either - only ever reached for its
+        // own `Stagger`.
+        if self.path.is_empty() {
+            return Some(Box::new(stagger_seconds(&scene.0.animation)?));
+        }
         let node = node_at(&scene.0.animation, &self.path)?;
 
         match (self.edit, node) {
@@ -389,6 +415,14 @@ impl Source for Property {
             return;
         };
         let scene = editor.edit();
+
+        if self.path.is_empty() {
+            if let Some(value) = f32::from_reflect(value) {
+                scene.0.animation.combinator =
+                    Combinator::Flow(clamp_seconds(value));
+            }
+            return;
+        }
         let Some(node) =
             node_at_mut(&mut scene.0.animation, &self.path)
         else {
@@ -430,10 +464,7 @@ fn seconds(node: &Node<Backend>, edit: Edit) -> Option<f32> {
             Some(delay.unwrap_or_default().as_secs_f32())
         }
         (Edit::Stagger, Node::Block { block, .. }) => {
-            match block.combinator {
-                Combinator::Flow(delay) => Some(delay.as_secs_f32()),
-                _ => None,
-            }
+            stagger_seconds(block)
         }
         (Edit::Duration, Node::Action { action, .. }) => {
             Some(action.duration.as_secs_f32())
@@ -442,10 +473,23 @@ fn seconds(node: &Node<Backend>, edit: Edit) -> Option<f32> {
     }
 }
 
+/// A `Flow` block's own stagger, in seconds - `None` for any other
+/// combinator.
+fn stagger_seconds(block: &Block<Backend>) -> Option<f32> {
+    match block.combinator {
+        Combinator::Flow(delay) => Some(delay.as_secs_f32()),
+        _ => None,
+    }
+}
+
+/// Never negative: nothing here runs backwards.
+fn clamp_seconds(value: f32) -> Duration {
+    Duration::from_secs_f32(value.max(0.0))
+}
+
 /// Writes one of the properties measured in seconds.
 fn set_seconds(node: &mut Node<Backend>, edit: Edit, value: f32) {
-    // Never negative: an action cannot run backwards.
-    let seconds = Duration::from_secs_f32(value.max(0.0));
+    let seconds = clamp_seconds(value);
 
     match (edit, node) {
         (Edit::Delay, Node::Block { delay, .. })

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -19,12 +19,10 @@ use fynix_mock::ui::ElementHandle;
 use motiongfx_scene::block::{ActionCmd, Block, Combinator, Node};
 use motiongfx_scene::refs::FieldRef;
 use moxie_ui::elements::{
-    Frame, Label, LabelCursor, ScrollArea, SegmentedControl,
-    display_name,
+    Frame, Label, ScrollArea, SegmentedControl, display_name,
 };
 use moxie_ui::inspector::{
-    FieldRow, Source, SourceExt, inspect_value, reflect_changed,
-    when_changed,
+    FieldRow, Source, inspect_value, reflect_changed,
 };
 use moxie_ui::reactive::{BevyHost, BevyUi, value_changed};
 
@@ -150,19 +148,6 @@ fn build(ui: &mut BevyUi) {
     }
 
     heading(ui, path.clone());
-    {
-        let source = Property {
-            path: path.clone(),
-            edit: Edit::Name,
-        };
-        ui.compose(FieldRow {
-            label: "Name".to_string(),
-            color: theme.text_muted,
-            bold: false,
-            depth: 0,
-            value: move |ui: &mut BevyUi| inspect_value(ui, &source),
-        });
-    }
     if let Some(subject) = shape.subject {
         let primary = theme.text_primary;
         let muted = theme.text_muted;
@@ -682,55 +667,17 @@ fn combinator_name(combinator: &Combinator) -> &'static str {
     }
 }
 
-/// The panel's heading: the node's name if set (bold, primary text),
-/// or an "Unnamed" placeholder (muted, not bold) - the same promotion
-/// the Name row below reads and writes. Bound to the same `Name`
-/// edit, so it stays live as that row is typed into.
+/// The panel's heading: the node's own name, editable directly rather
+/// than a read-only title plus a separate Name row beneath it -
+/// clicking it is what a text field already does. Reuses the same
+/// `Property`/`Edit::Name` source and the registered `String` widget
+/// every other text edit in this panel goes through.
 fn heading(ui: &mut BevyUi, path: Vec<usize>) {
-    let primary = ui.theme.text_primary;
-    let muted = ui.theme.text_muted;
-
     let source = Property {
         path,
         edit: Edit::Name,
     };
-    let named = shown_name(&source, ui.world);
-
-    ui.elem(elem!(
-        Label,
-        text = named.clone().unwrap_or_else(|| "Unnamed".into()),
-        bold = named.is_some(),
-        color = Some(if named.is_some() { primary } else { muted })
-    ))
-    .bind(|label| label.text(), when_changed(&source), {
-        let source = source.boxed();
-        move |world, _| {
-            shown_name(&*source, world)
-                .unwrap_or_else(|| "Unnamed".into())
-        }
-    })
-    .bind(|label| label.bold(), when_changed(&source), {
-        let source = source.boxed();
-        move |world, _| shown_name(&*source, world).is_some()
-    })
-    .bind(|label| label.color(), when_changed(&source), {
-        let source = source.boxed();
-        move |world, _| {
-            if shown_name(&*source, world).is_some() {
-                primary
-            } else {
-                muted
-            }
-        }
-    });
-}
-
-/// `source`'s current name, `None` for both an absent and a
-/// blank-after-trim one.
-fn shown_name(source: &dyn Source, world: &World) -> Option<String> {
-    source
-        .read::<String>(world)
-        .filter(|name| !name.trim().is_empty())
+    inspect_value(ui, &source);
 }
 
 /// What the panel says when there is nothing to show.

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -17,8 +17,10 @@ use fynix_mock::composer::Composer;
 use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
 use motiongfx_scene::block::{ActionCmd, Block, Combinator, Node};
-use moxie_ui::elements::{Frame, Label, ScrollArea};
-use moxie_ui::inspector::{Source, inspect_value, reflect_changed};
+use moxie_ui::elements::{Label, ScrollArea};
+use moxie_ui::inspector::{
+    FieldRow, Source, inspect_value, reflect_changed,
+};
 use moxie_ui::reactive::{BevyHost, BevyUi, value_changed};
 use moxie_ui::theme::EditorTheme;
 
@@ -115,32 +117,54 @@ fn build(ui: &mut BevyUi) {
     let shape = shape(ui.world, ui.parent());
 
     let Some(path) = shape.path else {
-        note(ui, theme, "Nothing selected");
+        note(ui, "Nothing selected");
         return;
     };
     if shape.kind.is_empty() {
-        note(ui, theme, "Selection is no longer in the scene");
+        note(ui, "Selection is no longer in the scene");
         return;
     }
 
     heading(ui, theme, shape.kind);
     for (name, value) in shape.rows {
-        row(ui, theme, &name, &value);
+        let primary = theme.text_primary;
+        ui.compose(FieldRow {
+            label: name,
+            color: theme.text_muted,
+            bold: false,
+            depth: 0,
+            value: move |ui: &mut BevyUi| {
+                ui.elem(elem!(
+                    Label,
+                    text = value,
+                    color = Some(primary),
+                    wrap = false
+                ));
+            },
+        });
     }
     for (name, edit) in shape.edits {
         let source = Property {
             path: path.clone(),
             edit,
         };
-        line(ui, name, theme.text_muted, move |ui| {
-            inspect_value(ui, &source);
+        ui.compose(FieldRow {
+            label: name,
+            color: theme.text_muted,
+            bold: false,
+            depth: 0,
+            value: move |ui: &mut BevyUi| inspect_value(ui, &source),
         });
     }
 
     // Whatever the registry has for the type it turns out to hold.
     if let Some(pooled) = shape.value {
-        line(ui, "Value".to_string(), theme.text_muted, move |ui| {
-            inspect_value(ui, &pooled);
+        ui.compose(FieldRow {
+            label: "Value".to_string(),
+            color: theme.text_muted,
+            bold: false,
+            depth: 0,
+            value: move |ui: &mut BevyUi| inspect_value(ui, &pooled),
         });
     }
 }
@@ -414,53 +438,11 @@ fn heading(ui: &mut BevyUi, theme: &EditorTheme, text: &str) {
     ));
 }
 
-/// One `name: value` line, for what this panel cannot change.
-fn row(
-    ui: &mut BevyUi,
-    theme: &EditorTheme,
-    name: &str,
-    value: &str,
-) {
-    let value = value.to_string();
-    let primary = theme.text_primary;
-
-    line(ui, name.to_string(), theme.text_muted, move |ui| {
-        ui.elem(elem!(
-            Label,
-            text = value,
-            color = Some(primary),
-            wrap = false
-        ));
-    });
-}
-
-/// The name on the left, whatever it takes on the right.
-fn line(
-    ui: &mut BevyUi,
-    name: String,
-    muted: Color,
-    body: impl FnOnce(&mut BevyUi),
-) {
-    ui.elem(elem!(
-        Frame,
-        width = percent(100),
-        direction = FlexDirection::Row,
-        justify = JustifyContent::SpaceBetween,
-        align = AlignItems::Center,
-        column_gap = px(8),
-        padding = UiRect::vertical(px(3))
-    ))
-    .with(move |ui| {
-        ui.elem(elem!(Label, text = name, color = Some(muted)));
-        body(ui);
-    });
-}
-
 /// What the panel says when there is nothing to show.
-fn note(ui: &mut BevyUi, theme: &EditorTheme, text: &str) {
+fn note(ui: &mut BevyUi, text: &str) {
     ui.elem(elem!(
         Label,
         text = text.to_string(),
-        color = Some(theme.text_muted)
+        color = Some(ui.theme.text_muted)
     ));
 }

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -17,7 +17,8 @@ use fynix_mock::composer::Composer;
 use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
 use motiongfx_scene::block::{ActionCmd, Block, Combinator, Node};
-use moxie_ui::elements::{Label, ScrollArea};
+use motiongfx_scene::refs::FieldRef;
+use moxie_ui::elements::{Label, ScrollArea, display_name};
 use moxie_ui::inspector::{
     FieldRow, Source, inspect_value, reflect_changed,
 };
@@ -218,8 +219,7 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
         value: Some(Pooled(action.value)),
         rows: vec![
             ("Subject".into(), subject_name(world, action)),
-            ("Type".into(), action.field.type_name().to_string()),
-            ("Field".into(), action.field.path().to_string()),
+            ("Field".into(), field_name(world, &action.field)),
             ("Operation".into(), format!("{:?}", action.op)),
         ],
         edits,
@@ -430,6 +430,32 @@ fn subject_name(world: &World, action: &ActionCmd<Backend>) -> String {
         Some(name) => format!("{name} #{head}"),
         None => format!("#{head}"),
     }
+}
+
+/// The type's own display name, the same [`ReflectInspectable`]-aware
+/// one the entity inspector shows it by, followed by the path to the
+/// field this action drives - `Transform::translation::x`. Falls back
+/// to the type path's own last segment when the registry has never
+/// heard of it.
+///
+/// [`ReflectInspectable`]: moxie_ui::inspector::ReflectInspectable
+fn field_name(world: &World, field: &FieldRef) -> String {
+    let type_name = field.type_name().to_string();
+    let registry = world.resource::<AppTypeRegistry>().read();
+
+    let name = registry
+        .get_with_type_path(&type_name)
+        .map(display_name)
+        .unwrap_or_else(|| {
+            type_name
+                .rsplit("::")
+                .next()
+                .unwrap_or(&type_name)
+                .to_string()
+                .into()
+        });
+
+    format!("{name}::{}", field.path())
 }
 
 fn combinator_name(combinator: &Combinator) -> &'static str {

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -12,7 +12,7 @@ use bevy::asset::uuid::Uuid;
 use bevy::prelude::*;
 use bevy::reflect::PartialReflect;
 use bevy_motiongfx::scene::backend::{AnimEase, AnimInterp, Backend};
-use bevy_motiongfx::scene::id::SceneUid;
+use bevy_motiongfx::scene::id::{SceneUid, SceneUidMap};
 use fynix_mock::composer::Composer;
 use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
@@ -24,7 +24,7 @@ use moxie_ui::inspector::{
 use moxie_ui::reactive::{BevyHost, BevyUi, value_changed};
 use moxie_ui::theme::EditorTheme;
 
-use super::PANEL_PADDING;
+use super::{PANEL_PADDING, hierarchy};
 use crate::{EditorScene, SelectedAction};
 
 /// The action panel, as kernel nodes.
@@ -217,7 +217,7 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
         kind: "Action",
         value: Some(Pooled(action.value)),
         rows: vec![
-            ("Subject".into(), subject_name(action)),
+            ("Subject".into(), subject_name(world, action)),
             ("Type".into(), action.field.type_name().to_string()),
             ("Field".into(), action.field.path().to_string()),
             ("Operation".into(), format!("{:?}", action.op)),
@@ -413,9 +413,23 @@ fn set_seconds(node: &mut Node<Backend>, edit: Edit, value: f32) {
     }
 }
 
-fn subject_name(action: &ActionCmd<Backend>) -> String {
+/// Its [`Name`], if it still has an entity, followed by the head of
+/// its id - a whole uuid is unreadable, but two entities sharing a
+/// name still need telling apart.
+fn subject_name(world: &World, action: &ActionCmd<Backend>) -> String {
     let SceneUid::Entity(uid) = action.subject;
-    format!("{uid}")
+    let head = hierarchy::uid_head(uid);
+
+    let name = world
+        .get_resource::<SceneUidMap>()
+        .and_then(|map| map.entity(uid))
+        .and_then(|entity| world.get::<Name>(entity))
+        .map(Name::as_str);
+
+    match name {
+        Some(name) => format!("{name} #{head}"),
+        None => format!("#{head}"),
+    }
 }
 
 fn combinator_name(combinator: &Combinator) -> &'static str {

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -19,13 +19,14 @@ use fynix_mock::ui::ElementHandle;
 use motiongfx_scene::block::{ActionCmd, Block, Combinator, Node};
 use motiongfx_scene::refs::FieldRef;
 use moxie_ui::elements::{
-    Frame, Label, ScrollArea, SegmentedControl, display_name,
+    Frame, Label, LabelCursor, ScrollArea, SegmentedControl,
+    display_name,
 };
 use moxie_ui::inspector::{
-    FieldRow, Source, inspect_value, reflect_changed,
+    FieldRow, Source, SourceExt, inspect_value, reflect_changed,
+    when_changed,
 };
 use moxie_ui::reactive::{BevyHost, BevyUi, value_changed};
-use moxie_ui::theme::EditorTheme;
 
 use super::{PANEL_PADDING, hierarchy};
 use crate::{EditorScene, SelectedAction};
@@ -54,7 +55,7 @@ impl Composer<BevyHost> for ActionPanel {
     }
 }
 
-/// One number in the selected node that an input writes back.
+/// One property of the selected node that an input writes back.
 ///
 /// Named, not captured: an input re-reads and rewrites it long after
 /// the panel was built.
@@ -70,6 +71,8 @@ enum Edit {
     Ease,
     /// How its values are blended.
     Interp,
+    /// The node's own name, block or action alike.
+    Name,
 }
 
 /// Everything a rebuild depends on. The numbers are deliberately
@@ -146,7 +149,20 @@ fn build(ui: &mut BevyUi) {
         return;
     }
 
-    heading(ui, theme, shape.kind);
+    heading(ui, shape.kind, path.clone());
+    {
+        let source = Property {
+            path: path.clone(),
+            edit: Edit::Name,
+        };
+        ui.compose(FieldRow {
+            label: "Name".to_string(),
+            color: theme.text_muted,
+            bold: false,
+            depth: 0,
+            value: move |ui: &mut BevyUi| inspect_value(ui, &source),
+        });
+    }
     if let Some(subject) = shape.subject {
         let primary = theme.text_primary;
         let muted = theme.text_muted;
@@ -422,12 +438,22 @@ impl Source for Property {
         let scene = world.get_resource::<EditorScene>()?.scene();
 
         // The root has no `Node` of its own, so no `Ease`, `Interp`,
-        // `Duration` or `Delay` either - only ever reached for its
-        // own `Stagger`.
+        // `Duration` or `Delay` - only ever reached for its own
+        // `Stagger` and `Name`.
         if self.path.is_empty() {
-            return Some(Box::new(stagger_seconds(
-                &scene.0.animation,
-            )?));
+            return match self.edit {
+                Edit::Name => Some(Box::new(
+                    scene
+                        .0
+                        .animation
+                        .name
+                        .clone()
+                        .unwrap_or_default(),
+                )),
+                _ => Some(Box::new(stagger_seconds(
+                    &scene.0.animation,
+                )?)),
+            };
         }
         let node = node_at(&scene.0.animation, &self.path)?;
 
@@ -439,6 +465,14 @@ impl Source for Property {
             ),
             (Edit::Interp, Node::Action { action, .. }) => Some(
                 Box::new(action.interp.unwrap_or(AnimInterp::Linear)),
+            ),
+            // Unset shows as the widget's own empty state, not a
+            // missing row.
+            (Edit::Name, Node::Block { block, .. }) => {
+                Some(Box::new(block.name.clone().unwrap_or_default()))
+            }
+            (Edit::Name, Node::Action { action, .. }) => Some(
+                Box::new(action.name.clone().unwrap_or_default()),
             ),
             _ => Some(Box::new(seconds(node, self.edit)?)),
         }
@@ -453,9 +487,18 @@ impl Source for Property {
         let scene = editor.edit();
 
         if self.path.is_empty() {
-            if let Some(value) = f32::from_reflect(value) {
-                scene.0.animation.combinator =
-                    Combinator::Flow(clamp_seconds(value));
+            match self.edit {
+                Edit::Name => {
+                    if let Some(value) = String::from_reflect(value) {
+                        scene.0.animation.name = named(value);
+                    }
+                }
+                _ => {
+                    if let Some(value) = f32::from_reflect(value) {
+                        scene.0.animation.combinator =
+                            Combinator::Flow(clamp_seconds(value));
+                    }
+                }
             }
             return;
         }
@@ -471,6 +514,16 @@ impl Source for Property {
             }
             (Edit::Interp, Node::Action { action, .. }) => {
                 action.interp = AnimInterp::from_reflect(value);
+            }
+            (Edit::Name, Node::Block { block, .. }) => {
+                if let Some(value) = String::from_reflect(value) {
+                    block.name = named(value);
+                }
+            }
+            (Edit::Name, Node::Action { action, .. }) => {
+                if let Some(value) = String::from_reflect(value) {
+                    action.name = named(value);
+                }
             }
             (edit, node) => {
                 if let Some(value) = f32::from_reflect(value) {
@@ -521,6 +574,13 @@ fn stagger_seconds(block: &Block<Backend>) -> Option<f32> {
 /// Never negative: nothing here runs backwards.
 fn clamp_seconds(value: f32) -> Duration {
     Duration::from_secs_f32(value.max(0.0))
+}
+
+/// Blank input clears a name back to `None`, rather than storing an
+/// empty string.
+fn named(value: String) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 /// Writes one of the properties measured in seconds.
@@ -622,14 +682,76 @@ fn combinator_name(combinator: &Combinator) -> &'static str {
     }
 }
 
-/// A section header, which is all this panel has by way of structure.
-fn heading(ui: &mut BevyUi, theme: &EditorTheme, text: &str) {
+/// The panel's heading: the node's name if set (bold, primary text),
+/// or an "Unnamed" placeholder (muted, not bold) - the same promotion
+/// the Name row below reads and writes - plus a small tag naming its
+/// kind. Bound to the same `Name` edit, so it stays live as that row
+/// is typed into.
+fn heading(ui: &mut BevyUi, kind: &'static str, path: Vec<usize>) {
+    let primary = ui.theme.text_primary;
+    let muted = ui.theme.text_muted;
+
+    let source = Property {
+        path,
+        edit: Edit::Name,
+    };
+    let named = shown_name(&source, ui.world);
+
     ui.elem(elem!(
-        Label,
-        text = text.to_string(),
-        bold = true,
-        color = Some(theme.text_primary)
-    ));
+        Frame,
+        direction = FlexDirection::Row,
+        align = AlignItems::Baseline,
+        column_gap = px(6)
+    ))
+    .with(move |ui| {
+        ui.elem(elem!(
+            Label,
+            text = named.clone().unwrap_or_else(|| "Unnamed".into()),
+            bold = named.is_some(),
+            color =
+                Some(if named.is_some() { primary } else { muted })
+        ))
+        .bind(|label| label.text(), when_changed(&source), {
+            let source = source.boxed();
+            move |world, _| {
+                shown_name(&*source, world)
+                    .unwrap_or_else(|| "Unnamed".into())
+            }
+        })
+        .bind(|label| label.bold(), when_changed(&source), {
+            let source = source.boxed();
+            move |world, _| shown_name(&*source, world).is_some()
+        })
+        .bind(
+            |label| label.color(),
+            when_changed(&source),
+            {
+                let source = source.boxed();
+                move |world, _| {
+                    if shown_name(&*source, world).is_some() {
+                        primary
+                    } else {
+                        muted
+                    }
+                }
+            },
+        );
+
+        ui.elem(elem!(
+            Label,
+            text = kind.to_string(),
+            size = 10.0f32,
+            color = Some(muted)
+        ));
+    });
+}
+
+/// `source`'s current name, `None` for both an absent and a
+/// blank-after-trim one.
+fn shown_name(source: &dyn Source, world: &World) -> Option<String> {
+    source
+        .read::<String>(world)
+        .filter(|name| !name.trim().is_empty())
 }
 
 /// What the panel says when there is nothing to show.

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -18,7 +18,9 @@ use fynix_mock::elem;
 use fynix_mock::ui::ElementHandle;
 use motiongfx_scene::block::{ActionCmd, Block, Combinator, Node};
 use motiongfx_scene::refs::FieldRef;
-use moxie_ui::elements::{Frame, Label, ScrollArea, display_name};
+use moxie_ui::elements::{
+    Frame, Label, ScrollArea, SegmentedControl, display_name,
+};
 use moxie_ui::inspector::{
     FieldRow, Source, inspect_value, reflect_changed,
 };
@@ -79,6 +81,9 @@ struct Shape {
     kind: &'static str,
     /// Set only for an action: a block has none to show.
     subject: Option<Subject>,
+    /// Set only for a block: which of Chain/All/Flow it is, for the
+    /// Type row's picker. An action has none to show.
+    combinator: Option<&'static str>,
     rows: Vec<(String, String)>,
     edits: Vec<(String, Edit)>,
     /// The action's target value. Which widget draws it is the
@@ -121,6 +126,7 @@ fn shape(world: &World, _: Entity) -> Shape {
             path,
             kind: "",
             subject: None,
+            combinator: None,
             rows: Vec::new(),
             edits: Vec::new(),
             value: None,
@@ -171,6 +177,39 @@ fn build(ui: &mut BevyUi) {
                         color = Some(muted),
                         wrap = false
                     ));
+                });
+            },
+        });
+    }
+    if let Some(combinator) = shape.combinator {
+        let selected = match combinator {
+            "Chain" => 0,
+            "All" => 1,
+            _ => 2,
+        };
+        let path = path.clone();
+        ui.compose(FieldRow {
+            label: "Type".to_string(),
+            color: theme.text_muted,
+            bold: false,
+            depth: 0,
+            value: move |ui: &mut BevyUi| {
+                ui.compose(SegmentedControl {
+                    options: vec![
+                        "Chain".to_string(),
+                        "All".to_string(),
+                        "Flow".to_string(),
+                    ],
+                    selected,
+                    on_select:
+                        move |i: usize, commands: &mut Commands| {
+                            let path = path.clone();
+                            commands.queue(
+                                move |world: &mut World| {
+                                    set_combinator(world, &path, i);
+                                },
+                            );
+                        },
                 });
             },
         });
@@ -253,6 +292,7 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
         path: Some(path.to_vec()),
         kind: "Action",
         subject: Some(subject_of(world, action)),
+        combinator: None,
         value: Some(Pooled(action.value)),
         rows: vec![
             ("Field".into(), field_name(world, &action.field)),
@@ -262,9 +302,8 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
     })
 }
 
-/// A block's own row of info: its combinator and child count, plus
-/// whatever of its timing the [`Node`] wrapping it (if any) lets
-/// through.
+/// A block's own row of info: its combinator, plus whatever of its
+/// timing the [`Node`] wrapping it (if any) lets through.
 fn block_shape(
     path: Vec<usize>,
     block: &Block<Backend>,
@@ -282,14 +321,9 @@ fn block_shape(
         path: Some(path),
         kind: "Block",
         subject: None,
+        combinator: Some(combinator_name(&block.combinator)),
         value: None,
-        rows: vec![
-            (
-                "Combinator".into(),
-                combinator_name(&block.combinator).to_string(),
-            ),
-            ("Children".into(), block.children.len().to_string()),
-        ],
+        rows: Vec::new(),
         edits,
     }
 }
@@ -391,7 +425,9 @@ impl Source for Property {
         // `Duration` or `Delay` either - only ever reached for its
         // own `Stagger`.
         if self.path.is_empty() {
-            return Some(Box::new(stagger_seconds(&scene.0.animation)?));
+            return Some(Box::new(stagger_seconds(
+                &scene.0.animation,
+            )?));
         }
         let node = node_at(&scene.0.animation, &self.path)?;
 
@@ -547,6 +583,34 @@ fn field_name(world: &World, field: &FieldRef) -> String {
         });
 
     format!("{name}{}", field.path())
+}
+
+/// Writes the block at `path` (the tree's own root, if empty) onto
+/// whichever of Chain/All/Flow the Type picker's `index` names.
+/// Switching into Flow seeds a default stagger; switching out of it
+/// drops whatever stagger it had.
+fn set_combinator(world: &mut World, path: &[usize], index: usize) {
+    let Some(mut editor) = world.get_resource_mut::<EditorScene>()
+    else {
+        return;
+    };
+    let scene = editor.edit();
+
+    let combinator = match index {
+        0 => Combinator::Chain,
+        1 => Combinator::All,
+        _ => Combinator::Flow(Duration::from_secs_f32(0.15)),
+    };
+
+    if path.is_empty() {
+        scene.0.animation.combinator = combinator;
+        return;
+    }
+    if let Some(Node::Block { block, .. }) =
+        node_at_mut(&mut scene.0.animation, path)
+    {
+        block.combinator = combinator;
+    }
 }
 
 fn combinator_name(combinator: &Combinator) -> &'static str {

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -433,15 +433,19 @@ fn is_subject(world: &World, entity: Entity) -> bool {
 /// Its [`Name`], or the head of its id. A whole uuid is unreadable;
 /// the first characters tell two unnamed subjects apart.
 fn name_of(world: &World, entity: Entity) -> String {
-    /// How much of an id a row shows.
-    const HEAD: usize = 8;
-
     if let Some(name) = world.get::<Name>(entity) {
         return name.as_str().to_string();
     }
 
     match world.get::<EntityUid>(entity) {
-        Some(uid) => uid.to_string().chars().take(HEAD).collect(),
+        Some(uid) => uid_head(*uid),
         None => "?".to_string(),
     }
+}
+
+/// How much of an id a row shows. A whole uuid is unreadable; the
+/// first characters are enough to tell two subjects apart.
+pub(crate) fn uid_head(uid: EntityUid) -> String {
+    const HEAD: usize = 8;
+    uid.to_string().chars().take(HEAD).collect()
 }

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -285,9 +285,9 @@ fn block_view(
 
 /// One box per placement: a block's header ([`TimelineBlock`], which
 /// owns its own label), or an action leaf's own [`TimelineAction`].
-/// The action lights up under the cursor and outlines in the theme's
-/// accent when [`SelectedAction`] names its path; clicking it writes
-/// that path in.
+/// Either outlines in the theme's accent when [`SelectedAction`] names
+/// its path, and clicking either writes that path in; only the action
+/// also lights up under the cursor.
 ///
 /// An `Any` block's box, and any ancestor its visual extent bleeds
 /// into, is already sized to its losing branch's full duration (see
@@ -307,6 +307,7 @@ fn build_block_boxes(ui: &mut BevyUi) {
 
         match placed.label {
             Some(label) => {
+                let path = placed.path.clone();
                 ui.elem(elem!(
                     TimelineBlock,
                     label = val!(
@@ -320,8 +321,18 @@ fn build_block_boxes(ui: &mut BevyUi) {
                     width = placed.w,
                     height = placed.h,
                     background = block_outline.with_alpha(0.04),
-                    border = block_outline.with_alpha(0.4)
-                ));
+                    border = if is_selected {
+                        accent
+                    } else {
+                        block_outline.with_alpha(0.4)
+                    }
+                ))
+                .observe(
+                    move |_: On<Activate>,
+                          mut selected: ResMut<SelectedAction>| {
+                        selected.0 = Some(path.clone());
+                    },
+                );
             }
             // An action leaf's own element: position, colors and
             // selection are all typed fields, and it owns its

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -341,6 +341,12 @@ fn build_block_boxes(ui: &mut BevyUi) {
                 let path = placed.path.clone();
                 ui.elem(elem!(
                     TimelineAction,
+                    label = val!(
+                        Label,
+                        text = placed.name.unwrap_or_default(),
+                        size = 10.0f32,
+                        color = Some(action_fill.with_alpha(0.9))
+                    ),
                     top = placed.y,
                     left = placed.x,
                     width = placed.w,

--- a/editor/moxie_ui/src/elements.rs
+++ b/editor/moxie_ui/src/elements.rs
@@ -50,6 +50,7 @@ pub use icon::{Icon, IconCursor, IconField};
 // nothing about them is stored to be patched later.
 pub use inspector::{
     ComponentInspector, EntityInspector, ResourceInspector,
+    display_name,
 };
 pub use label::{Label, LabelCursor, LabelField};
 pub use overlay::{Overlay, OverlayCursor, OverlayField};

--- a/editor/moxie_ui/src/elements.rs
+++ b/editor/moxie_ui/src/elements.rs
@@ -19,6 +19,7 @@ mod overlay;
 mod panel;
 mod playhead;
 mod scroll_area;
+mod segmented_control;
 mod tab;
 mod time_label;
 mod time_tick;
@@ -30,7 +31,7 @@ mod timeline_track;
 // it, and the walk is what those provide.
 pub use button::{
     Button, ButtonElem, ButtonElemCursor, ButtonElemField,
-    GhostButton, MenuButton, TintButton,
+    GhostButton, MenuButton, SegmentButton, TintButton,
 };
 pub use divider::{Divider, DividerCursor, DividerField};
 pub use dropdown::{
@@ -61,6 +62,7 @@ pub use playhead::{
 pub use scroll_area::{
     ScrollArea, ScrollAreaCursor, ScrollAreaField,
 };
+pub use segmented_control::SegmentedControl;
 pub use tab::{
     Tab, TabBar, TabBarCursor, TabBarField, TabCursor, TabField,
     TabRow, TabRowCursor, TabRowField,

--- a/editor/moxie_ui/src/elements/button.rs
+++ b/editor/moxie_ui/src/elements/button.rs
@@ -64,6 +64,11 @@ pub struct ButtonElem {
     pub padding: UiRect,
     #[default(::ZERO)]
     pub radius: Val,
+    /// Overrides `radius` with independent corners, for a button that
+    /// sits at one end of a row of others (a
+    /// [`SegmentedControl`](super::SegmentedControl)'s outer
+    /// segments). `None` rounds all four corners by `radius`.
+    pub corners: Option<BorderRadius>,
     /// Set by whichever [`Style`] built this - see [`Hover`]. Never
     /// patched: read once, in `build_fields`.
     #[elem(ignore)]
@@ -82,7 +87,9 @@ impl ButtonElem {
             align_items: AlignItems::Center,
             column_gap: self.column_gap,
             padding: self.padding,
-            border_radius: BorderRadius::all(self.radius),
+            border_radius: self
+                .corners
+                .unwrap_or(BorderRadius::all(self.radius)),
             ..default()
         }
     }
@@ -266,7 +273,8 @@ impl ElementVisual<BevyHost> for ButtonElem {
             | ButtonElemField::Justify
             | ButtonElemField::ColumnGap
             | ButtonElemField::Padding
-            | ButtonElemField::Radius => {
+            | ButtonElemField::Radius
+            | ButtonElemField::Corners => {
                 patch.insert(self.node());
             }
         }

--- a/editor/moxie_ui/src/elements/button.rs
+++ b/editor/moxie_ui/src/elements/button.rs
@@ -147,6 +147,34 @@ impl Style for MenuButton {
     }
 }
 
+/// One segment of a [`SegmentedControl`](super::SegmentedControl):
+/// filled solid with the theme's accent when `active`, its theme fill
+/// otherwise. Rounding is the control's own, not each segment's - it
+/// clips its row of children rather than rounding them individually.
+pub struct SegmentButton {
+    pub active: bool,
+}
+
+impl Style for SegmentButton {
+    type Host = BevyHost;
+    type Element = ButtonElem;
+
+    fn apply(self, button: &mut ButtonElem, theme: &EditorTheme) {
+        button.height = px(24);
+        button.flex_grow = 1.0;
+        button.fill = if self.active {
+            theme.accent
+        } else {
+            theme.button_fill
+        };
+        button.hover = if self.active {
+            Hover::None
+        } else {
+            Hover::Fill(theme.hover_overlay)
+        };
+    }
+}
+
 /// A button with no surface of its own until the cursor is on it, for
 /// one that sits in a row of its own kind or on something that is
 /// already a surface.

--- a/editor/moxie_ui/src/elements/field.rs
+++ b/editor/moxie_ui/src/elements/field.rs
@@ -223,6 +223,16 @@ impl TextField {
         if let Some(mut layout) = world.get_mut::<Node>(node) {
             layout.width = self.width;
             layout.flex_grow = 0.0;
+
+            // `FeathersTextInputContainer` reserves its left inset as
+            // a colorless 3px *border* rather than padding (room for
+            // a leading icon we never add), which leaves the
+            // background unpainted there and the left corners looking
+            // square next to the fully rounded right ones. Folding it
+            // into padding instead paints the background - and so the
+            // radius - all the way around.
+            layout.border = UiRect::ZERO;
+            layout.padding = UiRect::horizontal(px(3.0));
         }
 
         self.show(world, node);

--- a/editor/moxie_ui/src/elements/inspector.rs
+++ b/editor/moxie_ui/src/elements/inspector.rs
@@ -30,7 +30,7 @@ use super::{
 };
 use crate::icons;
 use crate::inspector::{
-    Field, InspectorFields, ReflectInspectable, Section, field_row,
+    Field, FieldRow, InspectorFields, ReflectInspectable, Section,
     inspect_value, single_value,
 };
 use crate::motion::MotionExt;
@@ -42,7 +42,7 @@ pub struct ComponentInspector {
     pub entity: Entity,
     pub component: TypeId,
     /// How many [`Foldable`](crate::fold::Foldable) bodies this sits
-    /// under, for `field_row` to keep its columns aligned. `0` for
+    /// under, for `FieldRow` to keep its columns aligned. `0` for
     /// a call site with none of its own.
     pub depth: u32,
 }
@@ -334,8 +334,12 @@ fn single(ui: &mut BevyUi, name: &str, field: Field) {
     let name = name.to_string();
     let primary = ui.theme.text_primary;
 
-    field_row(ui, name, primary, true, 0, move |ui| {
-        inspect_value(ui, &field);
+    ui.compose(FieldRow {
+        label: name,
+        color: primary,
+        bold: true,
+        depth: 0,
+        value: move |ui: &mut BevyUi| inspect_value(ui, &field),
     });
 }
 

--- a/editor/moxie_ui/src/elements/inspector.rs
+++ b/editor/moxie_ui/src/elements/inspector.rs
@@ -412,7 +412,7 @@ fn inspectable(
 
 /// What [`ReflectInspectable::name`] overrides to, or `T`'s own name
 /// split into words.
-fn display_name(
+pub fn display_name(
     registration: &TypeRegistration,
 ) -> Cow<'static, str> {
     if let Some(name) = registration

--- a/editor/moxie_ui/src/elements/segmented_control.rs
+++ b/editor/moxie_ui/src/elements/segmented_control.rs
@@ -1,0 +1,83 @@
+//! A row of mutually exclusive options, as a composer rather than an
+//! element - it builds a subtree of [`ButtonElem`]s, none of it kept
+//! around to be patched later.
+
+use bevy::prelude::*;
+use bevy::ui_widgets::Activate;
+use bevy_fynix::EntityExt as _;
+use fynix_mock::composer::Composer;
+use fynix_mock::ui::ElementHandle;
+use fynix_mock::{elem, val};
+
+use super::{Frame, Label, SegmentButton};
+use crate::reactive::{BevyHost, BevyUi};
+
+/// A 3-way (or more) radio, one option filled solid - bevy_feathers'
+/// own `RoundedCorners`/`ButtonVariant::Primary` pattern, rounded only
+/// at the row's own ends (the row clips its children rather than
+/// rounding each segment) with a 1px gap as the seam between segments,
+/// not a divider line.
+pub struct SegmentedControl<F> {
+    pub options: Vec<String>,
+    pub selected: usize,
+    /// `Commands` to queue a world write with, since picking a segment
+    /// only fires from inside its own `Activate` observer.
+    pub on_select: F,
+}
+
+impl<F> Composer<BevyHost> for SegmentedControl<F>
+where
+    F: Fn(usize, &mut Commands) + Clone + Send + Sync + 'static,
+{
+    type Element = Frame;
+
+    fn compose(
+        self,
+        ui: &mut BevyUi,
+    ) -> ElementHandle<BevyHost, Frame> {
+        let Self {
+            options,
+            selected,
+            on_select,
+        } = self;
+        let theme = ui.theme;
+
+        ui.elem(elem!(
+            Frame,
+            width = percent(100),
+            direction = FlexDirection::Row,
+            column_gap = px(1),
+            radius = px(4),
+            overflow = Overflow::clip()
+        ))
+        .with(move |ui| {
+            for (i, label) in options.into_iter().enumerate() {
+                let active = i == selected;
+                let text_color = if active {
+                    theme.palette.base[0]
+                } else {
+                    theme.text_primary
+                };
+                let on_select = on_select.clone();
+
+                ui.elem(elem!(
+                    !SegmentButton { active },
+                    label = val!(
+                        Label,
+                        text = label,
+                        size = 11.0f32,
+                        bold = active,
+                        wrap = false,
+                        color = Some(text_color)
+                    )
+                ))
+                .observe(
+                    move |_: On<Activate>, mut commands: Commands| {
+                        on_select(i, &mut commands);
+                    },
+                );
+            }
+        })
+        .handle()
+    }
+}

--- a/editor/moxie_ui/src/elements/segmented_control.rs
+++ b/editor/moxie_ui/src/elements/segmented_control.rs
@@ -13,10 +13,10 @@ use super::{Frame, Label, SegmentButton};
 use crate::reactive::{BevyHost, BevyUi};
 
 /// A 3-way (or more) radio, one option filled solid - bevy_feathers'
-/// own `RoundedCorners`/`ButtonVariant::Primary` pattern, rounded only
-/// at the row's own ends (the row clips its children rather than
-/// rounding each segment) with a 1px gap as the seam between segments,
-/// not a divider line.
+/// own `RoundedCorners`/`ButtonVariant::Primary` pattern: only the
+/// row's own two ends are rounded, each segment its own corners rather
+/// than the row clipping a straight-edged strip, with a 1px gap as the
+/// seam between segments, not a divider line.
 pub struct SegmentedControl<F> {
     pub options: Vec<String>,
     pub selected: usize,
@@ -42,13 +42,13 @@ where
         } = self;
         let theme = ui.theme;
 
+        let count = options.len();
+
         ui.elem(elem!(
             Frame,
             width = percent(100),
             direction = FlexDirection::Row,
-            column_gap = px(1),
-            radius = px(4),
-            overflow = Overflow::clip()
+            column_gap = px(1)
         ))
         .with(move |ui| {
             for (i, label) in options.into_iter().enumerate() {
@@ -58,10 +58,12 @@ where
                 } else {
                     theme.text_primary
                 };
+                let corners = segment_corners(i, count);
                 let on_select = on_select.clone();
 
                 ui.elem(elem!(
                     !SegmentButton { active },
+                    corners = Some(corners),
                     label = val!(
                         Label,
                         text = label,
@@ -80,4 +82,22 @@ where
         })
         .handle()
     }
+}
+
+/// The corner radius for the segment at `index` of `count`: rounded on
+/// whichever side (or both, or neither) sits at the row's own edge.
+/// Not themed yet - see the backlog entry to give `EditorTheme` a
+/// button corner radius and use it here and everywhere else a button
+/// rounds itself.
+fn segment_corners(index: usize, count: usize) -> BorderRadius {
+    let radius = px(4);
+    let first = index == 0;
+    let last = index == count - 1;
+
+    BorderRadius::new(
+        if first { radius } else { Val::ZERO },
+        if last { radius } else { Val::ZERO },
+        if last { radius } else { Val::ZERO },
+        if first { radius } else { Val::ZERO },
+    )
 }

--- a/editor/moxie_ui/src/elements/segmented_control.rs
+++ b/editor/moxie_ui/src/elements/segmented_control.rs
@@ -1,6 +1,8 @@
 //! A row of mutually exclusive options, as a composer rather than an
 //! element - it builds a subtree of [`ButtonElem`]s, none of it kept
 //! around to be patched later.
+//!
+//! [`ButtonElem`]: crate::elements::button::ButtonElem
 
 use bevy::prelude::*;
 use bevy::ui_widgets::Activate;

--- a/editor/moxie_ui/src/elements/timeline_action.rs
+++ b/editor/moxie_ui/src/elements/timeline_action.rs
@@ -7,10 +7,18 @@ use bevy_fynix::EntityExt as _;
 use fynix_mock::element::{Element, ElementVisual};
 use fynix_mock::ui::{Build, Patch};
 
+use super::Label;
+
 /// One action's clip on the timeline: a colored, absolutely
-/// positioned, bordered hit area.
+/// positioned, bordered hit area, its name (if any) pinned to its
+/// top-left corner exactly like [`TimelineBlock`](super::TimelineBlock)'s -
+/// clipped rather than measured, so a bar too narrow for it just
+/// shows nothing instead of overflowing its neighbor.
 #[derive(Element)]
 pub struct TimelineAction {
+    /// Blank when the action has no name of its own.
+    #[elem(child)]
+    pub label: Label,
     pub top: f32,
     pub left: f32,
     pub width: f32,
@@ -32,6 +40,8 @@ impl TimelineAction {
             left: px(self.left),
             width: px(self.width),
             height: px(self.height),
+            padding: UiRect::new(px(4), Val::ZERO, px(2), Val::ZERO),
+            overflow: Overflow::clip(),
             border: UiRect::all(px(if self.selected {
                 2
             } else {

--- a/editor/moxie_ui/src/elements/timeline_block.rs
+++ b/editor/moxie_ui/src/elements/timeline_block.rs
@@ -1,5 +1,8 @@
 use crate::reactive::BevyHost;
+use bevy::feathers::cursor::EntityCursor;
 use bevy::prelude::*;
+use bevy::ui_widgets::Button as ButtonBehavior;
+use bevy::window::SystemCursorIcon;
 use bevy_fynix::EntityExt as _;
 use fynix_mock::element::{Element, ElementVisual};
 use fynix_mock::ui::{Build, Patch};
@@ -11,6 +14,10 @@ use super::Label;
 /// `Node::Block` in a scene's animation tree gets one of these -
 /// an action leaf has no children and so no label, and stays a plain
 /// `Frame` instead.
+///
+/// Clickable exactly like [`TimelineAction`](super::TimelineAction):
+/// it carries the same [`ButtonBehavior`], so a click fires
+/// `Activate` the caller can select it on.
 #[derive(Element)]
 pub struct TimelineBlock {
     #[elem(child)]
@@ -49,6 +56,8 @@ impl ElementVisual<BevyHost> for TimelineBlock {
             self.node(),
             BackgroundColor(self.background),
             BorderColor::all(self.border),
+            ButtonBehavior,
+            EntityCursor::System(SystemCursorIcon::Pointer),
         ));
     }
 

--- a/editor/moxie_ui/src/inspector.rs
+++ b/editor/moxie_ui/src/inspector.rs
@@ -269,7 +269,7 @@ pub fn inspect_value(ui: &mut BevyUi, source: &dyn Source) {
 /// which would otherwise pull the 40% mark inward with it; the label
 /// sheds that same width back so `value` starts at the same place
 /// no matter how deep its row is nested.
-pub struct FieldRow<F> {
+pub struct FieldRow<F: FnOnce(&mut BevyUi)> {
     pub label: String,
     pub color: Color,
     pub bold: bool,

--- a/editor/moxie_ui/src/inspector.rs
+++ b/editor/moxie_ui/src/inspector.rs
@@ -24,12 +24,14 @@ use std::any::TypeId;
 use bevy::light::CascadeShadowConfig;
 use bevy::prelude::*;
 use bevy::reflect::{FromType, GetTypeRegistration, PartialReflect};
+use fynix_mock::composer::Composer;
 use fynix_mock::elem;
+use fynix_mock::ui::ElementHandle;
 use moxie_asset::AssetKindAppExt;
 
 use crate::elements::{Frame, Label};
 use crate::fold;
-use crate::reactive::BevyUi;
+use crate::reactive::{BevyHost, BevyUi};
 pub use field::Field;
 pub(crate) use tree::single_value;
 pub use tree::{InspectorFields, Section};
@@ -267,48 +269,65 @@ pub fn inspect_value(ui: &mut BevyUi, source: &dyn Source) {
 /// which would otherwise pull the 40% mark inward with it; the label
 /// sheds that same width back so `value` starts at the same place
 /// no matter how deep its row is nested.
-pub(crate) fn field_row(
-    ui: &mut BevyUi,
-    label: String,
-    color: Color,
-    bold: bool,
-    depth: u32,
-    value: impl FnOnce(&mut BevyUi),
-) {
-    const VALUE_SHARE: f32 = 0.6;
-    const LABEL_SIZE: f32 = 12.0;
-    const EDGE_PADDING: f32 = 8.0;
-    let indent = ui.theme.fold_indent + fold::RAIL_WIDTH;
-    let shed = VALUE_SHARE * depth as f32 * indent;
+pub struct FieldRow<F> {
+    pub label: String,
+    pub color: Color,
+    pub bold: bool,
+    pub depth: u32,
+    pub value: F,
+}
 
-    ui.elem(elem!(
-        Frame,
-        width = percent(100),
-        direction = FlexDirection::Row,
-        align = AlignItems::Center,
-        column_gap = px(8),
-        padding = UiRect::vertical(px(3))
-    ))
-    .with(move |ui| {
+impl<F: FnOnce(&mut BevyUi)> Composer<BevyHost> for FieldRow<F> {
+    type Element = Frame;
+
+    fn compose(
+        self,
+        ui: &mut BevyUi,
+    ) -> ElementHandle<BevyHost, Frame> {
+        let Self {
+            label,
+            color,
+            bold,
+            depth,
+            value,
+        } = self;
+
+        const VALUE_SHARE: f32 = 0.6;
+        const LABEL_SIZE: f32 = 12.0;
+        const EDGE_PADDING: f32 = 8.0;
+        let indent = ui.theme.fold_indent + fold::RAIL_WIDTH;
+        let shed = VALUE_SHARE * depth as f32 * indent;
+
         ui.elem(elem!(
             Frame,
-            width = percent(40),
-            margin = UiRect::right(px(-shed)),
-            overflow = Overflow::clip_x(),
-            padding = UiRect::right(px(EDGE_PADDING))
+            width = percent(100),
+            direction = FlexDirection::Row,
+            align = AlignItems::Center,
+            column_gap = px(8),
+            padding = UiRect::vertical(px(3))
         ))
         .with(move |ui| {
             ui.elem(elem!(
-                Label,
-                text = label,
-                size = LABEL_SIZE,
-                color = Some(color),
-                bold = bold,
-                wrap = false
-            ));
-        });
-        ui.elem(elem!(Frame, flex_grow = 1.0f32)).with(value);
-    });
+                Frame,
+                width = percent(40),
+                margin = UiRect::right(px(-shed)),
+                overflow = Overflow::clip_x(),
+                padding = UiRect::right(px(EDGE_PADDING))
+            ))
+            .with(move |ui| {
+                ui.elem(elem!(
+                    Label,
+                    text = label,
+                    size = LABEL_SIZE,
+                    color = Some(color),
+                    bold = bold,
+                    wrap = false
+                ));
+            });
+            ui.elem(elem!(Frame, flex_grow = 1.0f32)).with(value);
+        })
+        .handle()
+    }
 }
 
 /// Builds the editing widget for one reflected value.

--- a/editor/moxie_ui/src/inspector/handle.rs
+++ b/editor/moxie_ui/src/inspector/handle.rs
@@ -100,6 +100,6 @@ fn label_of<T: Asset>(world: &World, source: &dyn Source) -> String {
     world
         .get_resource::<AssetServer>()
         .and_then(|assets| assets.get_path(&handle))
-        .map(|path| path.path().display().to_string())
+        .map(|path| path.to_string())
         .unwrap_or_else(|| "(unnamed)".to_string())
 }

--- a/editor/moxie_ui/src/inspector/tree.rs
+++ b/editor/moxie_ui/src/inspector/tree.rs
@@ -18,7 +18,7 @@ use fynix_mock::records::BuildFn;
 use fynix_mock::ui::{ElementHandle, ElementMut};
 use fynix_mock::{elem, val};
 
-use super::{Field, ReflectInspect, enums, field_row};
+use super::{Field, FieldRow, ReflectInspect, enums};
 use crate::elements::{ButtonElem, Frame, Icon, Label, TintButton};
 use crate::fold::{CHEVRON_SHUT, Foldable, FoldsOn};
 use crate::icons;
@@ -267,7 +267,7 @@ fn shape_changed(field: Field) -> impl FnMut(&World, Entity) -> bool {
 /// whole component at the empty path.
 pub struct InspectorFields {
     pub root: Field,
-    /// How many [`Foldable`] bodies this sits under, for `field_row`
+    /// How many [`Foldable`] bodies this sits under, for `FieldRow`
     /// to keep its columns aligned. `0` for a call site with none of
     /// its own.
     pub depth: u32,
@@ -347,8 +347,12 @@ fn build_leaf(
     let muted = ui.theme.text_muted;
     let label = leaf_name(&path).to_string();
     let field = root.child(&path);
-    field_row(ui, label, muted, false, depth, move |ui| {
-        drawer.build(&field, ui);
+    ui.compose(FieldRow {
+        label,
+        color: muted,
+        bold: false,
+        depth,
+        value: move |ui: &mut BevyUi| drawer.build(&field, ui),
     });
 }
 
@@ -369,12 +373,18 @@ fn build_variant(
 
     if children.is_empty() {
         let label = leaf_name(&path).to_string();
-        field_row(ui, label, muted, false, depth, move |ui| {
-            ui.compose(enums::VariantPicker {
-                source: &field,
-                variants,
-                pick,
-            });
+        ui.compose(FieldRow {
+            label,
+            color: muted,
+            bold: false,
+            depth,
+            value: move |ui: &mut BevyUi| {
+                ui.compose(enums::VariantPicker {
+                    source: &field,
+                    variants,
+                    pick,
+                });
+            },
         });
         return;
     }


### PR DESCRIPTION
Major changes is in the `Combinator` enum.
Also adds an optional `name` field to `Block` & `ActionCmd`.