### PR TITLE
Add `Draft` variant to `Node`

### DIFF
--- a/crates/bevy_motiongfx/tests/asset.rs
+++ b/crates/bevy_motiongfx/tests/asset.rs
@@ -54,6 +54,7 @@ fn cube_scene_deserializes() {
                         action.subject
                     );
                 }
+                Node::Draft { .. } => {}
             }
         }
     }

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -169,6 +169,16 @@ impl TrackFragment {
         }
     }
 
+    /// A fragment with no clips of its own, reserving `duration` of
+    /// time - for a slot in the tree nothing resolves into an action
+    /// yet.
+    pub fn silent(duration: Duration) -> Self {
+        Self {
+            sequences: HashMap::new(),
+            duration,
+        }
+    }
+
     /// Updates or inserts a [`Sequence`] in a track.
     ///
     /// If the [`ActionKey`] already exists, this method appends the

--- a/crates/motiongfx_scene/src/block.rs
+++ b/crates/motiongfx_scene/src/block.rs
@@ -1,8 +1,8 @@
 //! The animation tree: nested [`Block`]s of [`Node`]s.
 //!
 //! A [`Block`] carries a [`Combinator`] for how its children combine;
-//! a [`Node`] is a nested block, an action leaf, or a delayed wrapper.
-//! Each maps 1:1 onto a `motiongfx` track combinator.
+//! a [`Node`] is a nested block, an action leaf, or an unassigned
+//! draft, each with its own delay.
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -72,6 +72,15 @@ pub enum Node<B: SceneBackend> {
         delay: Option<Duration>,
         action: ActionCmd<B>,
     },
+    /// Not yet a real action: reserves a timing slot without a
+    /// subject or field picked yet.
+    Draft {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        delay: Option<Duration>,
+        duration: Duration,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
 }
 
 impl<B: SceneBackend> Node<B> {
@@ -88,12 +97,22 @@ impl<B: SceneBackend> Node<B> {
         }
     }
 
+    /// An unassigned slot of `duration`, starting with its parent.
+    pub fn draft(duration: Duration) -> Self {
+        Self::Draft {
+            delay: None,
+            duration,
+            name: None,
+        }
+    }
+
     /// Offsets this node's start by `offset`, replacing any existing
     /// delay.
     pub fn delay(mut self, offset: Duration) -> Self {
         *match &mut self {
             Self::Block { delay, .. }
-            | Self::Action { delay, .. } => delay,
+            | Self::Action { delay, .. }
+            | Self::Draft { delay, .. } => delay,
         } = Some(offset);
         self
     }

--- a/crates/motiongfx_scene/src/compile.rs
+++ b/crates/motiongfx_scene/src/compile.rs
@@ -79,6 +79,9 @@ fn walk_node<B: SceneBackend>(
             delay,
             resolve_action(action, registry, values, builder)?,
         ),
+        Node::Draft {
+            delay, duration, ..
+        } => (delay, TrackFragment::silent(*duration)),
     };
 
     Ok(match offset {

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -164,8 +164,19 @@ editor, not just fails cleanly. Demoting the orphaned action to a
 draft instead turns "the whole scene stops compiling" into "one action
 needs reassignment."
 
-Two different triggers, two different demotion shapes:
+Two different triggers, two different demotion shapes - plus a third,
+generic one that landed first, as a safety net rather than a proactive
+fix:
 
+- [x] `recompile_dirty_scene`: a `CompileError` no longer panics the
+      editor. `demote_offending_action` walks the tree for whichever
+      `Node::Action` the error names (by subject/field/op/value/ease/
+      interp, matching the error variant), demotes just that one, and
+      retries - looping until it compiles or nothing more can be
+      demoted. Catches anything unresolvable regardless of cause (a
+      hand-edited scene file, a typo'd field path), not only the two
+      triggers below - but reactive, not proactive: it only runs the
+      next time something recompiles, not the instant an entity dies.
 - [ ] Entity deleted: subject itself is gone, so nothing about the
       action is still valid. Extend the existing `on_remove_entity_uid`
       observer (`bevy_motiongfx/scene/id.rs`, already keeps

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -109,16 +109,23 @@ plumbing. The alternative (an editor-only staging list outside
 `scene.0.animation`) would need its own parallel selection, placement,
 and timing concept instead of reusing what's there.
 
-- [ ] `Node::Draft` variant. New match arm everywhere `Node` is
+- [x] `Node::Draft` variant. New match arm everywhere `Node` is
       matched exhaustively: `walk_node` (compile.rs), `measure_node`
-      (block_layout.rs), `node_at`/`node_at_mut`/`summarize`/
-      `Property::get`/`set` (action.rs).
-- [ ] `compile()`: a draft resolves to an empty/no-op `TrackFragment`
-      of its own duration - reserves its timing slot without needing
-      anything else resolved. Not a `CompileError`; being incomplete
-      isn't being broken.
-- [ ] Action panel: a draft's Subject/Field rows are pickers, not
-      display text.
+      (block_layout.rs, plus `node_duration`), `summarize`/
+      `Property::get`/`set`/`seconds`/`set_seconds` (action.rs).
+      `node_at`/`node_at_mut` needed no change - they already fall
+      through on anything that isn't `Node::Block`.
+- [x] `compile()`: a draft resolves to `TrackFragment::silent(duration)`
+      (new, alongside `TrackFragment::new`/`single`) - a fragment with
+      no clips that still reserves its timing slot. Not a
+      `CompileError`; being incomplete isn't being broken.
+- [x] Action panel: `draft_shape` - Duration/Delay/Name are real edits
+      (the same `Property` machinery Action/Block already use);
+      Subject/Field are still plain "Unassigned" text for now. The
+      picker UI itself is its own follow-up, not built this round.
+- [x] Timeline: a draft's clip reads as an empty slot (a faint outline,
+      no fill, "Draft" label) rather than a real action's solid fill -
+      `Placed` grew a `draft: bool`.
 
 ### Graduating: draft to action
 

--- a/editor/docs/action-editing.md
+++ b/editor/docs/action-editing.md
@@ -64,14 +64,28 @@ deserializes with `None`, no migration needed (unlike `Any` above).
 
 ## Collapsible blocks
 
-Reuses `moxie_ui::fold::Foldable` - the same chevron/rail the entity
-inspector's own sections already use, not a new mechanism.
+`Foldable` itself doesn't apply here - it's a vertical-list composer
+(header row, then an indented body below), and the timeline is
+absolutely-positioned boxes on a time axis, not a flex column. What's
+reused instead is the convention: `fold::CHEVRON_SHUT`/`CHEVRON_OPEN`
+rotation values and a `BTreeSet<Vec<usize>>` fold-state resource
+(`timeline::BlockFoldState`), the same shape `assets::AssetFoldState`
+already uses for the asset browser's own folder tree.
 
-- [ ] `TimelineBlock` gets a chevron (`fold::CHEVRON_SHUT`/`CHEVRON_OPEN`
-      convention) that toggles a folded state per block.
-- [ ] Collapsed: children hidden, header strip alone still spans the
-      block's full duration and shows its name - same as a collapsed
-      folder track in any NLE.
+- [x] `BlockFoldState`, by path. `block_layout::layout` takes it and
+      threads it through measurement: a folded block's children are
+      skipped (empty, not built) and its height drops to just the
+      header strip's - its duration is untouched, so it still
+      contributes its full width/timing to siblings. Toggling is a
+      plain `value_changed(block_view)` rebuild, same as any other
+      timeline edit - no extra resource-changed wiring needed, since
+      `Placed` already reflects the new state.
+- [x] The chevron is its own absolutely-positioned element beside
+      `TimelineBlock`'s header, not nested inside it - a nested
+      `AlignItems::Center` row centers in the whole block's height
+      (header *and* all its content), not just the header strip,
+      since that's the box's real height. Independent positioning
+      sidesteps that entirely.
 
 ## Unassigned actions (`Node::Draft`)
 

--- a/editor/moxie/src/block_layout.rs
+++ b/editor/moxie/src/block_layout.rs
@@ -38,6 +38,9 @@ pub(crate) struct Placed {
     /// `true` when a block's children are folded away. Always `false`
     /// for an action leaf.
     pub(crate) folded: bool,
+    /// `true` for a `Node::Draft` leaf - an unassigned slot, styled
+    /// apart from a real action.
+    pub(crate) draft: bool,
     /// This node's position in `animation`'s tree: child index at
     /// each depth, root first. What [`crate::SelectedAction`] compares
     /// against, so a click can name exactly which node it landed on.
@@ -80,6 +83,9 @@ enum MeasuredKind {
     Action {
         name: Option<String>,
     },
+    Draft {
+        name: Option<String>,
+    },
     Block {
         label: String,
         folded: bool,
@@ -116,6 +122,9 @@ fn node_duration(node: &Node<Backend>) -> Duration {
         Node::Block { delay, block } => {
             (delay, block_duration(block))
         }
+        Node::Draft {
+            delay, duration, ..
+        } => (delay, *duration),
     };
     inner.saturating_add(delay.unwrap_or_default())
 }
@@ -155,9 +164,9 @@ fn measure_node(
     path: &mut Vec<usize>,
 ) -> Measured {
     let delay = match node {
-        Node::Action { delay, .. } | Node::Block { delay, .. } => {
-            delay.unwrap_or_default()
-        }
+        Node::Action { delay, .. }
+        | Node::Block { delay, .. }
+        | Node::Draft { delay, .. } => delay.unwrap_or_default(),
     };
     let start = start.saturating_add(delay);
 
@@ -169,6 +178,12 @@ fn measure_node(
             kind: MeasuredKind::Action {
                 name: action.name.clone(),
             },
+        },
+        Node::Draft { duration, name, .. } => Measured {
+            start,
+            end: start.saturating_add(*duration),
+            height: ROW_HEIGHT,
+            kind: MeasuredKind::Draft { name: name.clone() },
         },
         Node::Block { block, .. } => {
             measure_block(block, start, folded, path)
@@ -313,6 +328,19 @@ fn flatten(
             label: None,
             name: name.clone(),
             folded: false,
+            draft: false,
+            path: path.clone(),
+        }),
+        MeasuredKind::Draft { name } => out.push(Placed {
+            x,
+            y,
+            w,
+            h: measured.height,
+            depth,
+            label: None,
+            name: name.clone(),
+            folded: false,
+            draft: true,
             path: path.clone(),
         }),
         MeasuredKind::Block {
@@ -329,6 +357,7 @@ fn flatten(
                 label: Some(label.clone()),
                 name: None,
                 folded: *folded,
+                draft: false,
                 path: path.clone(),
             });
             let content_top = y + HEADER_HEIGHT;

--- a/editor/moxie/src/block_layout.rs
+++ b/editor/moxie/src/block_layout.rs
@@ -9,6 +9,7 @@
 //! rather than implying the relationship through indentation.
 
 use core::time::Duration;
+use std::collections::BTreeSet;
 
 use bevy_motiongfx::scene::backend::Backend;
 use motiongfx_scene::block::{Block, Combinator, Node};
@@ -34,6 +35,9 @@ pub(crate) struct Placed {
     /// An action leaf's own name, if set. `None` for a block - its
     /// name, if any, is already folded into `label`.
     pub(crate) name: Option<String>,
+    /// `true` when a block's children are folded away. Always `false`
+    /// for an action leaf.
+    pub(crate) folded: bool,
     /// This node's position in `animation`'s tree: child index at
     /// each depth, root first. What [`crate::SelectedAction`] compares
     /// against, so a click can name exactly which node it landed on.
@@ -42,8 +46,19 @@ pub(crate) struct Placed {
 
 /// Every box in `animation`'s tree, depth-first. `animation` itself
 /// gets a box too, at depth `0`, as the timeline's outer frame.
-pub(crate) fn layout(animation: &Block<Backend>) -> Vec<Placed> {
-    let root = measure_block(animation, Duration::ZERO);
+///
+/// `folded` names every block whose children are collapsed away - its
+/// duration is unaffected, only its height and its children's boxes.
+pub(crate) fn layout(
+    animation: &Block<Backend>,
+    folded: &BTreeSet<Vec<usize>>,
+) -> Vec<Placed> {
+    let root = measure_block(
+        animation,
+        Duration::ZERO,
+        folded,
+        &mut Vec::new(),
+    );
     let mut out = Vec::new();
     flatten(&root, 0.0, 0, &mut Vec::new(), &mut out);
     out
@@ -67,6 +82,7 @@ enum MeasuredKind {
     },
     Block {
         label: String,
+        folded: bool,
         children: Vec<(f32, Measured)>,
     },
 }
@@ -92,7 +108,8 @@ fn combinator_label(combinator: &Combinator) -> String {
 
 /// A node's own duration, including its `delay`: how much it advances
 /// its parent block's chain/flow position. Mirrors the timing math
-/// `motiongfx::track`'s `chain`/`flow` apply at compile time.
+/// `motiongfx::track`'s `chain`/`flow` apply at compile time. Not
+/// affected by folding.
 fn node_duration(node: &Node<Backend>) -> Duration {
     let (delay, inner) = match node {
         Node::Action { delay, action } => (delay, action.duration),
@@ -131,7 +148,12 @@ fn block_duration(block: &Block<Backend>) -> Duration {
     }
 }
 
-fn measure_node(node: &Node<Backend>, start: Duration) -> Measured {
+fn measure_node(
+    node: &Node<Backend>,
+    start: Duration,
+    folded: &BTreeSet<Vec<usize>>,
+    path: &mut Vec<usize>,
+) -> Measured {
     let delay = match node {
         Node::Action { delay, .. } | Node::Block { delay, .. } => {
             delay.unwrap_or_default()
@@ -148,22 +170,37 @@ fn measure_node(node: &Node<Backend>, start: Duration) -> Measured {
                 name: action.name.clone(),
             },
         },
-        Node::Block { block, .. } => measure_block(block, start),
+        Node::Block { block, .. } => {
+            measure_block(block, start, folded, path)
+        }
     }
 }
 
 fn measure_block(
     block: &Block<Backend>,
     start: Duration,
+    folded: &BTreeSet<Vec<usize>>,
+    path: &mut Vec<usize>,
 ) -> Measured {
-    let (children, content_height) =
-        measure_children(&block.children, &block.combinator, start);
+    let is_folded = folded.contains(path.as_slice());
+    let (children, content_height) = if is_folded {
+        (Vec::new(), 0.0)
+    } else {
+        measure_children(
+            &block.children,
+            &block.combinator,
+            start,
+            folded,
+            path,
+        )
+    };
     Measured {
         start,
         end: start.saturating_add(block_duration(block)),
         height: HEADER_HEIGHT + content_height,
         kind: MeasuredKind::Block {
             label: block_label(block),
+            folded: is_folded,
             children,
         },
     }
@@ -183,6 +220,8 @@ fn measure_children(
     children: &[Node<Backend>],
     combinator: &Combinator,
     block_start: Duration,
+    folded: &BTreeSet<Vec<usize>>,
+    path: &mut Vec<usize>,
 ) -> (Vec<(f32, Measured)>, f32) {
     if children.is_empty() {
         return (Vec::new(), 0.0);
@@ -214,7 +253,13 @@ fn measure_children(
     let measured: Vec<Measured> = children
         .iter()
         .zip(starts)
-        .map(|(child, start)| measure_node(child, start))
+        .enumerate()
+        .map(|(i, (child, start))| {
+            path.push(i);
+            let measured = measure_node(child, start, folded, path);
+            path.pop();
+            measured
+        })
         .collect();
 
     let ys: Vec<f32> = match combinator {
@@ -267,9 +312,14 @@ fn flatten(
             depth,
             label: None,
             name: name.clone(),
+            folded: false,
             path: path.clone(),
         }),
-        MeasuredKind::Block { label, children } => {
+        MeasuredKind::Block {
+            label,
+            folded,
+            children,
+        } => {
             out.push(Placed {
                 x,
                 y,
@@ -278,6 +328,7 @@ fn flatten(
                 depth,
                 label: Some(label.clone()),
                 name: None,
+                folded: *folded,
                 path: path.clone(),
             });
             let content_top = y + HEADER_HEIGHT;

--- a/editor/moxie/src/scene.rs
+++ b/editor/moxie/src/scene.rs
@@ -7,10 +7,11 @@ use bevy::prelude::*;
 use bevy_motiongfx::prelude::*;
 use bevy_motiongfx::scene::asset::MotionGfxScene;
 use bevy_motiongfx::scene::backend::{
-    BackendRegistry, default_scene_registry,
+    Backend, BackendRegistry, default_scene_registry,
 };
 use bevy_motiongfx::scene::value_pool::ValuePool;
-use motiongfx_scene::block::Block;
+use motiongfx_scene::block::{ActionCmd, Block, Node};
+use motiongfx_scene::error::CompileError;
 use motiongfx_scene::scene::{Scene, Stage};
 
 /// The project: a scene plus the registry that resolves its names.
@@ -69,7 +70,7 @@ impl Default for EditorScene {
 /// Scheduled with `run_if(resource_changed::<EditorScene>)`, so this
 /// only runs when [`EditorScene::edit`] actually landed a write.
 pub(crate) fn recompile_dirty_scene(world: &mut World) {
-    world.resource_scope::<EditorScene, _>(|world, editor_scene| {
+    world.resource_scope::<EditorScene, _>(|world, mut editor_scene| {
         world.resource_scope::<MotionGfxManager, _>(
             |world, mut manager| {
                 let mut q_players =
@@ -87,10 +88,28 @@ pub(crate) fn recompile_dirty_scene(world: &mut World) {
                     manager.remove_timeline(&old_id);
                 }
 
-                let new_id = editor_scene
-                    .scene
-                    .compile(&editor_scene.registry, &mut manager)
-                    .expect("editor scene should compile");
+                let new_id = loop {
+                    match editor_scene
+                        .scene
+                        .compile(&editor_scene.registry, &mut manager)
+                    {
+                        Ok(id) => break id,
+                        Err(err) => {
+                            if !demote_offending_action(
+                                &mut editor_scene.scene.0.animation,
+                                &err,
+                            ) {
+                                error!(
+                                    "scene can't compile and no action could be demoted: {err}"
+                                );
+                                return;
+                            }
+                            warn!(
+                                "demoted an action the scene can't compile: {err}"
+                            );
+                        }
+                    }
+                };
 
                 editor_scene
                     .scene
@@ -125,4 +144,59 @@ pub(crate) fn recompile_dirty_scene(world: &mut World) {
             },
         );
     });
+}
+
+/// Finds the first `Node::Action` under `block` that `error` names as
+/// unresolvable, and turns it into a `Node::Draft` in place - keeping
+/// its timing and name, dropping the subject/field/op/value `error`
+/// says is broken. `true` if it found and demoted one.
+fn demote_offending_action(
+    block: &mut Block<Backend>,
+    error: &CompileError<Backend>,
+) -> bool {
+    for child in &mut block.children {
+        if let Node::Block { block, .. } = child {
+            if demote_offending_action(block, error) {
+                return true;
+            }
+            continue;
+        }
+        let Node::Action { delay, action } = child else {
+            continue;
+        };
+        if !matches_error(action, error) {
+            continue;
+        }
+
+        let (delay, duration, name) =
+            (*delay, action.duration, action.name.clone());
+        *child = Node::Draft {
+            delay,
+            duration,
+            name,
+        };
+        return true;
+    }
+
+    false
+}
+
+fn matches_error(
+    action: &ActionCmd<Backend>,
+    error: &CompileError<Backend>,
+) -> bool {
+    match error {
+        CompileError::UnknownSubject(id) => action.subject == *id,
+        CompileError::UnknownField(field)
+        | CompileError::UnknownSubjectKind(field)
+        | CompileError::TypeMismatch { field, .. } => {
+            action.field == *field
+        }
+        CompileError::UnknownOp(_, op) => action.op == *op,
+        CompileError::UnknownValue(value) => action.value == *value,
+        CompileError::UnknownEase(ease) => action.ease == Some(*ease),
+        CompileError::UnknownInterp(interp) => {
+            action.interp == Some(*interp)
+        }
+    }
 }

--- a/editor/moxie/src/ui.rs
+++ b/editor/moxie/src/ui.rs
@@ -42,6 +42,7 @@ impl Plugin for UiPlugin {
             .init_resource::<ProjectBookmarks>()
             .init_resource::<ProjectPath>()
             .init_resource::<assets::AssetFoldState>()
+            .init_resource::<timeline::BlockFoldState>()
             .init_resource::<hierarchy::Dragging>()
             .init_resource::<scene::EditorScene>()
             .add_systems(Startup, setup_editor_ui)

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -279,6 +279,9 @@ fn summarize(world: &World, path: &[usize]) -> Option<Shape> {
         Node::Block { block, delay } => {
             return Some(block_shape(path.to_vec(), block, *delay));
         }
+        Node::Draft { delay, .. } => {
+            return Some(draft_shape(path.to_vec(), *delay));
+        }
         Node::Action { action, delay } => (delay, action),
     };
 
@@ -325,6 +328,30 @@ fn block_shape(
         combinator: Some(combinator_name(&block.combinator)),
         value: None,
         rows: Vec::new(),
+        edits,
+    }
+}
+
+/// A draft's own row of info - a subject and field yet to be picked,
+/// so its Subject/Field rows are placeholder text for now rather than
+/// the pickers that will land alongside dragging a field onto the
+/// timeline.
+fn draft_shape(path: Vec<usize>, delay: Option<Duration>) -> Shape {
+    let mut edits = vec![("Duration".to_string(), Edit::Duration)];
+    if delay.is_some() {
+        edits.push(("Delay".to_string(), Edit::Delay));
+    }
+
+    Shape {
+        path: Some(path),
+        kind: "Draft",
+        subject: None,
+        combinator: None,
+        value: None,
+        rows: vec![
+            ("Subject".into(), "Unassigned".into()),
+            ("Field".into(), "Unassigned".into()),
+        ],
         edits,
     }
 }
@@ -459,6 +486,9 @@ impl Source for Property {
             (Edit::Name, Node::Action { action, .. }) => Some(
                 Box::new(action.name.clone().unwrap_or_default()),
             ),
+            (Edit::Name, Node::Draft { name, .. }) => {
+                Some(Box::new(name.clone().unwrap_or_default()))
+            }
             _ => Some(Box::new(seconds(node, self.edit)?)),
         }
     }
@@ -510,6 +540,11 @@ impl Source for Property {
                     action.name = named(value);
                 }
             }
+            (Edit::Name, Node::Draft { name, .. }) => {
+                if let Some(value) = String::from_reflect(value) {
+                    *name = named(value);
+                }
+            }
             (edit, node) => {
                 if let Some(value) = f32::from_reflect(value) {
                     set_seconds(node, edit, value);
@@ -534,7 +569,8 @@ impl Source for Property {
 fn seconds(node: &Node<Backend>, edit: Edit) -> Option<f32> {
     match (edit, node) {
         (Edit::Delay, Node::Block { delay, .. })
-        | (Edit::Delay, Node::Action { delay, .. }) => {
+        | (Edit::Delay, Node::Action { delay, .. })
+        | (Edit::Delay, Node::Draft { delay, .. }) => {
             Some(delay.unwrap_or_default().as_secs_f32())
         }
         (Edit::Stagger, Node::Block { block, .. }) => {
@@ -542,6 +578,9 @@ fn seconds(node: &Node<Backend>, edit: Edit) -> Option<f32> {
         }
         (Edit::Duration, Node::Action { action, .. }) => {
             Some(action.duration.as_secs_f32())
+        }
+        (Edit::Duration, Node::Draft { duration, .. }) => {
+            Some(duration.as_secs_f32())
         }
         _ => None,
     }
@@ -574,7 +613,8 @@ fn set_seconds(node: &mut Node<Backend>, edit: Edit, value: f32) {
 
     match (edit, node) {
         (Edit::Delay, Node::Block { delay, .. })
-        | (Edit::Delay, Node::Action { delay, .. }) => {
+        | (Edit::Delay, Node::Action { delay, .. })
+        | (Edit::Delay, Node::Draft { delay, .. }) => {
             *delay = Some(seconds);
         }
         (Edit::Stagger, Node::Block { block, .. }) => {
@@ -582,6 +622,9 @@ fn set_seconds(node: &mut Node<Backend>, edit: Edit, value: f32) {
         }
         (Edit::Duration, Node::Action { action, .. }) => {
             action.duration = seconds;
+        }
+        (Edit::Duration, Node::Draft { duration, .. }) => {
+            *duration = seconds;
         }
         _ => {}
     }

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -315,6 +315,7 @@ fn build_block_boxes(ui: &mut BevyUi) {
     let action_fill = theme.palette.blue;
     let block_outline = theme.text_primary;
     let accent = theme.accent;
+    let critical = theme.critical;
     let hover_tint = theme.clip_hover;
     let press_tint = theme.clip_press;
 
@@ -402,9 +403,10 @@ fn build_block_boxes(ui: &mut BevyUi) {
             None => {
                 let path = placed.path.clone();
                 // A draft has no subject/field yet, so its clip reads
-                // as an empty slot rather than a real action's fill.
+                // as an empty slot in the critical color, rather than
+                // a real action's fill.
                 let fill = if placed.draft {
-                    block_outline.with_alpha(0.08)
+                    critical.with_alpha(0.12)
                 } else {
                     action_fill.with_alpha(0.35)
                 };
@@ -421,7 +423,7 @@ fn build_block_boxes(ui: &mut BevyUi) {
                             }),
                         size = 10.0f32,
                         color = Some(if placed.draft {
-                            block_outline.with_alpha(0.5)
+                            critical.with_alpha(0.9)
                         } else {
                             action_fill.with_alpha(0.9)
                         })
@@ -434,7 +436,7 @@ fn build_block_boxes(ui: &mut BevyUi) {
                     border = if is_selected {
                         accent
                     } else if placed.draft {
-                        block_outline.with_alpha(0.3)
+                        critical.with_alpha(0.5)
                     } else {
                         Color::NONE
                     },

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -401,21 +401,40 @@ fn build_block_boxes(ui: &mut BevyUi) {
             // pointer cursor and hover/press tint itself.
             None => {
                 let path = placed.path.clone();
+                // A draft has no subject/field yet, so its clip reads
+                // as an empty slot rather than a real action's fill.
+                let fill = if placed.draft {
+                    block_outline.with_alpha(0.08)
+                } else {
+                    action_fill.with_alpha(0.35)
+                };
                 ui.elem(elem!(
                     TimelineAction,
                     label = val!(
                         Label,
-                        text = placed.name.unwrap_or_default(),
+                        text = placed
+                            .name
+                            .unwrap_or_else(|| if placed.draft {
+                                "Draft".to_string()
+                            } else {
+                                String::new()
+                            }),
                         size = 10.0f32,
-                        color = Some(action_fill.with_alpha(0.9))
+                        color = Some(if placed.draft {
+                            block_outline.with_alpha(0.5)
+                        } else {
+                            action_fill.with_alpha(0.9)
+                        })
                     ),
                     top = placed.y,
                     left = placed.x,
                     width = placed.w,
                     height = placed.h,
-                    fill = action_fill.with_alpha(0.35),
+                    fill = fill,
                     border = if is_selected {
                         accent
+                    } else if placed.draft {
+                        block_outline.with_alpha(0.3)
                     } else {
                         Color::NONE
                     },

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -312,12 +312,6 @@ fn block_view(
 fn build_block_boxes(ui: &mut BevyUi) {
     let (placements, selected) = block_view(ui.world, ui.parent());
     let theme = ui.theme;
-    let action_fill = theme.palette.blue;
-    let block_outline = theme.text_primary;
-    let accent = theme.accent;
-    let critical = theme.critical;
-    let hover_tint = theme.clip_hover;
-    let press_tint = theme.clip_press;
 
     for placed in placements {
         let is_selected = selected.as_ref() == Some(&placed.path);
@@ -331,17 +325,17 @@ fn build_block_boxes(ui: &mut BevyUi) {
                         Label,
                         text = label,
                         size = 10.0f32,
-                        color = Some(block_outline.with_alpha(0.8))
+                        color = Some(theme.text_primary.with_alpha(0.8))
                     ),
                     top = placed.y,
                     left = placed.x,
                     width = placed.w,
                     height = placed.h,
-                    background = block_outline.with_alpha(0.04),
+                    background = theme.text_primary.with_alpha(0.04),
                     border = if is_selected {
-                        accent
+                        theme.accent
                     } else {
-                        block_outline.with_alpha(0.4)
+                        theme.text_primary.with_alpha(0.4)
                     }
                 ))
                 .observe(
@@ -379,7 +373,7 @@ fn build_block_boxes(ui: &mut BevyUi) {
                             Icon,
                             image = moxie_ui::icons::CHEVRON,
                             size = px(7),
-                            color = block_outline.with_alpha(0.6),
+                            color = theme.text_primary.with_alpha(0.6),
                             rotation = if folded {
                                 CHEVRON_SHUT
                             } else {
@@ -406,9 +400,9 @@ fn build_block_boxes(ui: &mut BevyUi) {
                 // as an empty slot in the critical color, rather than
                 // a real action's fill.
                 let fill = if placed.draft {
-                    critical.with_alpha(0.12)
+                    theme.critical.with_alpha(0.12)
                 } else {
-                    action_fill.with_alpha(0.35)
+                    theme.palette.blue.with_alpha(0.35)
                 };
                 ui.elem(elem!(
                     TimelineAction,
@@ -423,9 +417,9 @@ fn build_block_boxes(ui: &mut BevyUi) {
                             }),
                         size = 10.0f32,
                         color = Some(if placed.draft {
-                            critical.with_alpha(0.9)
+                            theme.critical.with_alpha(0.9)
                         } else {
-                            action_fill.with_alpha(0.9)
+                            theme.palette.blue.with_alpha(0.9)
                         })
                     ),
                     top = placed.y,
@@ -434,15 +428,15 @@ fn build_block_boxes(ui: &mut BevyUi) {
                     height = placed.h,
                     fill = fill,
                     border = if is_selected {
-                        accent
+                        theme.accent
                     } else if placed.draft {
-                        critical.with_alpha(0.5)
+                        theme.critical.with_alpha(0.5)
                     } else {
                         Color::NONE
                     },
                     selected = is_selected
                 ))
-                .lit(|action| action.fill(), hover_tint, press_tint)
+                .lit(|action| action.fill(), theme.clip_hover, theme.clip_press)
                 .observe(
                     move |_: On<Activate>,
                           mut selected: ResMut<SelectedAction>| {

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -3,6 +3,7 @@
 //! block's own header box already carries its label.
 
 use core::time::Duration;
+use std::collections::BTreeSet;
 
 use bevy::picking::events::{Click, Pointer};
 use bevy::prelude::*;
@@ -27,12 +28,24 @@ use moxie_ui::elements::{
     Button, ButtonElemCursor, Frame, Icon, IconCursor, Label,
     LabelCursor, Panel, PlayheadLine, PlayheadLineCursor, ScrollArea,
     TimeLabel, TimeTick, TimelineAction, TimelineActionCursor,
-    TimelineBlock,
+    TimelineBlock, TintButton,
 };
+use moxie_ui::fold::{CHEVRON_OPEN, CHEVRON_SHUT};
 use moxie_ui::motion::MotionExt;
 use moxie_ui::reactive::{
     BevyHost, BevyUi, resource_changed, value_changed,
 };
+
+/// Folded blocks, by path.
+#[derive(Resource, Default, Clone, PartialEq)]
+pub(super) struct BlockFoldState(BTreeSet<Vec<usize>>);
+
+fn toggle_folded(world: &mut World, path: &[usize]) {
+    let mut state = world.resource_mut::<BlockFoldState>();
+    if !state.0.remove(path) {
+        state.0.insert(path.to_vec());
+    }
+}
 
 const CONTROL_BAR_HEIGHT: f32 = 40.0;
 const TIME_AXIS_HEIGHT: f32 = 24.0;
@@ -262,10 +275,18 @@ fn current_time(world: &World, _: Entity) -> Duration {
 
 /// The editor scene's animation tree, laid out as nested boxes.
 fn block_placements(world: &World, _: Entity) -> Vec<Placed> {
+    let empty = BTreeSet::new();
+    let folded = world
+        .get_resource::<BlockFoldState>()
+        .map_or(&empty, |state| &state.0);
+
     world
         .get_resource::<EditorScene>()
         .map(|editor_scene| {
-            block_layout::layout(&editor_scene.scene().0.animation)
+            block_layout::layout(
+                &editor_scene.scene().0.animation,
+                folded,
+            )
         })
         .unwrap_or_default()
 }
@@ -288,11 +309,6 @@ fn block_view(
 /// Either outlines in the theme's accent when [`SelectedAction`] names
 /// its path, and clicking either writes that path in; only the action
 /// also lights up under the cursor.
-///
-/// An `Any` block's box, and any ancestor its visual extent bleeds
-/// into, is already sized to its losing branch's full duration (see
-/// [`block_layout::layout`]), so nothing here needs to clip or fade
-/// anything to keep a slower action visible.
 fn build_block_boxes(ui: &mut BevyUi) {
     let (placements, selected) = block_view(ui.world, ui.parent());
     let theme = ui.theme;
@@ -333,6 +349,52 @@ fn build_block_boxes(ui: &mut BevyUi) {
                         selected.0 = Some(path.clone());
                     },
                 );
+
+                // Its own element, absolutely positioned over the
+                // block's top-left corner rather than nested in
+                // `TimelineBlock`: a nested row would need
+                // `AlignItems::Center` to line up with the label,
+                // which centers in the whole block's height instead
+                // of just the header strip.
+                let path = placed.path.clone();
+                let folded = placed.folded;
+                ui.elem(elem!(
+                    Frame,
+                    position = PositionType::Absolute,
+                    inset = UiRect::new(
+                        px(placed.x),
+                        auto(),
+                        px(placed.y),
+                        auto()
+                    ),
+                    width = px(12),
+                    height = px(12)
+                ))
+                .with(move |ui| {
+                    ui.elem(elem!(
+                        !TintButton::default(),
+                        radius = px(3),
+                        icon = val!(
+                            Icon,
+                            image = moxie_ui::icons::CHEVRON,
+                            size = px(7),
+                            color = block_outline.with_alpha(0.6),
+                            rotation = if folded {
+                                CHEVRON_SHUT
+                            } else {
+                                CHEVRON_OPEN
+                            }
+                        )
+                    ))
+                    .observe(
+                        move |_: On<Activate>, mut commands: Commands| {
+                            let path = path.clone();
+                            commands.queue(move |world: &mut World| {
+                                toggle_folded(world, &path);
+                            });
+                        },
+                    );
+                });
             }
             // An action leaf's own element: position, colors and
             // selection are all typed fields, and it owns its

--- a/editor/moxie_ui/src/elements/timeline_block.rs
+++ b/editor/moxie_ui/src/elements/timeline_block.rs
@@ -10,9 +10,13 @@ use fynix_mock::ui::{Build, Patch};
 use super::Label;
 
 /// A block's header box: an absolutely positioned, bordered container
-/// with its label pinned to its top-left corner. Every
-/// `Node::Block` in a scene's animation tree gets one of these -
-/// an action leaf has no children and so no label, and stays a plain
+/// with its label pinned to its top-left corner, left padded to leave
+/// room for a fold chevron drawn on top of it separately - a nested
+/// row here would need `AlignItems::Center` to line the two up, which
+/// (this box spanning the block's full height, not just its header
+/// strip) centers the row in the whole block instead. Every
+/// `Node::Block` in a scene's animation tree gets one of these - an
+/// action leaf has no children and so no label, and stays a plain
 /// `Frame` instead.
 ///
 /// Clickable exactly like [`TimelineAction`](super::TimelineAction):
@@ -42,8 +46,9 @@ impl TimelineBlock {
             height: px(self.height),
             // The label sits in normal flow rather than absolute, so
             // this padding alone is what pins it to the top-left
-            // corner.
-            padding: UiRect::new(px(4), Val::ZERO, px(2), Val::ZERO),
+            // corner - left wide enough to clear the chevron drawn
+            // over it.
+            padding: UiRect::new(px(16), Val::ZERO, px(2), Val::ZERO),
             border: UiRect::all(px(1)),
             ..default()
         }


### PR DESCRIPTION
Add `Draft` variant to `Node` for:

1. Drafting actions/blocks
2. Gracefully handle unknown blocks/actions!