### PR TITLE
Extract `OverrideDefault` into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3041,6 +3041,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "lenz",
  "motiongfx_interp",
+ "override_default",
  "typarena",
 ]
 
@@ -4629,6 +4630,15 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "override_default"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ moxie_ui = { version = "0.3.0", path = "editor/moxie_ui" }
 moxie_asset = { version = "0.3.0", path = "editor/moxie_asset" }
 lenz = { version = "0.3.0", path = "crates/lenz" }
 lenz_macros = { version = "0.3.0", path = "crates/lenz_macros" }
+override_default = { version = "0.3.0", path = "crates/override_default" }
 fynix = { version = "0.3.0", path = "crates/fynix" }
 fynix_macros = { version = "0.3.0", path = "crates/fynix_macros" }
 bevy_fynix = { version = "0.3.0", path = "crates/bevy_fynix" }

--- a/crates/fynix/Cargo.toml
+++ b/crates/fynix/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 lenz = { workspace = true }
+override_default = { workspace = true }
 fynix_macros = { workspace = true }
 hashbrown = { workspace = true, features = ["default-hasher"] }
 motiongfx_interp = { workspace = true }

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -84,7 +84,9 @@ pub use ::lenz;
 ///
 /// An enum starts in the variant marked `#[default]`, and that
 /// variant's own fields take the attribute as any other field does.
-pub use fynix_macros::OverrideDefault;
+///
+/// The derive itself is the [`override_default`] crate.
+pub use override_default::OverrideDefault;
 
 /// Owns every watcher and binding, and the tree they maintain.
 pub struct Fynix<H: Host> {

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -1,12 +1,12 @@
 //! Derive macros for `fynix`.
 //!
-//! `#[derive(Lenz)]` for field paths lives in the `lenz` crate, which
-//! `fynix` re-exports; `#[element]` derives what it and
-//! `#[derive(OverrideDefault)]` would as part of its own output.
+//! `#[derive(Lenz)]` for field paths lives in the `lenz` crate and
+//! `#[derive(OverrideDefault)]` in the `override_default` crate, both
+//! re-exported by `fynix`; `#[element]` emits what they and its own
+//! dispatch would.
 
 mod common;
 mod element;
-mod override_default;
 
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
@@ -37,22 +37,6 @@ pub fn element(args: TokenStream, input: TokenStream) -> TokenStream {
     }
     let ast = parse_macro_input!(input as DeriveInput);
     match element::expand(&ast) {
-        Ok(tokens) => tokens.into(),
-        Err(err) => err.into_compile_error().into(),
-    }
-}
-
-/// Generates a `Default` impl where a field can start from something
-/// other than its own default: `#[default(px(4))]` for a value, or
-/// `#[default(size: 24)]` to keep the field's default and override
-/// fields of it.
-///
-/// `#[element]` emits this for its own struct - reach for it directly
-/// only for one that is never an element at all.
-#[proc_macro_derive(OverrideDefault, attributes(default))]
-pub fn derive_override_default(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    match override_default::expand(&ast) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.into_compile_error().into(),
     }

--- a/crates/override_default/Cargo.toml
+++ b/crates/override_default/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "override_default"
+description = "A `Default` derive where a field can start from something other than its own default."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["derive", "full"] }
+
+[lints]
+workspace = true

--- a/crates/override_default/src/expand.rs
+++ b/crates/override_default/src/expand.rs
@@ -5,10 +5,34 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
     Data, DataEnum, DeriveInput, Expr, Field, FieldValue, Fields,
-    GenericParam, PathArguments, Token, Type, Variant,
+    GenericArgument, GenericParam, PathArguments, Token, Type,
+    Variant,
 };
 
-use crate::common::option_inner;
+/// The `T` of an `Option<T>`, if that is what this type is.
+fn option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    if path.qself.is_some() {
+        return None;
+    }
+
+    let segment = path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+
+    let PathArguments::AngleBracketed(args) = &segment.arguments
+    else {
+        return None;
+    };
+
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    })
+}
 
 /// What `#[default(..)]` says a field starts as.
 enum Start {

--- a/crates/override_default/src/lib.rs
+++ b/crates/override_default/src/lib.rs
@@ -1,0 +1,31 @@
+//! A `Default` derive where a field can start from something other
+//! than its own default.
+
+mod expand;
+
+use proc_macro::TokenStream;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Generates a `Default` impl where a field can start from something
+/// other than its own default: `#[default(px(4))]` for a value, or
+/// `#[default(size: 24)]` to keep the field's default and override
+/// fields of it.
+///
+/// - `#[default(px(4))]` - this value, whole.
+/// - `#[default(::Bold)]` - a variant of the field's own type.
+/// - `#[default(size: 24, weight: 400)]` - the field's own default,
+///   with these of its fields overridden (`0: 1, 1: 2` for a tuple).
+/// - `#[default(_, 8, ..)]` - the same, written as the pattern it
+///   looks like; `_` and `..` keep what the default had.
+/// - `#[default(..)]` - an `Option` field holding its inner default.
+///
+/// An enum starts in the variant marked `#[default]`, and that
+/// variant's own fields take the attribute as any other field does.
+#[proc_macro_derive(OverrideDefault, attributes(default))]
+pub fn derive_override_default(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    match expand::expand(&ast) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.into_compile_error().into(),
+    }
+}

--- a/docs/lenz_split.md
+++ b/docs/lenz_split.md
@@ -1,6 +1,6 @@
 # Splitting `lenz` out of `fynix`
 
-Plan, agreed but not built. The rest of `fynix` stays one crate: its
+Done. See the checklist at the end. The rest of `fynix` stays one crate: its
 kernel (`element`, `ui`, `records`, `lanes`, `composer`, `Fynix`) is a
 single dependency cycle and cannot be cut without turning `pub(crate)`
 plumbing into `pub` API. `lenz` is the exception - `lenz.rs` names
@@ -105,3 +105,10 @@ All done:
       files import `element` from `fynix::element` and drop the unused
       `Element` trait import (test files that call `Element::build`
       directly keep it).
+- [x] `OverrideDefault` extracted into its own single proc-macro crate
+      `override_default` (its codegen references no crate, only
+      `::core::default::Default`, so no `crate =` override - just the
+      derive plus a vendored `option_inner`). `fynix` re-exports it;
+      `#[element]` emits `#[derive(fynix::OverrideDefault)]`, which
+      resolves through the re-export. `fynix_macros/src/override_default.rs`
+      is gone.


### PR DESCRIPTION
`#[element]` emits `#[derive(fynix::OverrideDefault)]`, so the derive only needs to be invocable - its output names no crate, just `::core::default::Default`. Move it to a single proc-macro crate `override_default` (the derive plus a vendored `option_inner`), which `fynix` re-exports. No `crate =` override: there is no path in the output for one to redirect.

`fynix_macros` is now just `#[element]` and its shared helpers.