### PR TITLE
Redesign `#[element]` with per-field patch/build hooks

### DIFF
--- a/crates/bevy_fynix/tests/flush.rs
+++ b/crates/bevy_fynix/tests/flush.rs
@@ -7,14 +7,14 @@ use bevy_fynix::host::BevyHost;
 use bevy_fynix::{FynixPlugin, WorldEntityRef as _, watch_root};
 use bevy_ui::Node;
 use fynix::elem;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+use fynix::ui::Patch;
 
 /// Nothing in these tests reads a theme - a host still needs one.
 #[derive(Resource, Clone, Default)]
 struct NoTheme;
 
-type Host = BevyHost<NoTheme>;
+type FynixHost = BevyHost<NoTheme>;
 
 /// What the element writes. A real one would write `bevy_ui`
 /// components; this only has to be visible from a test.
@@ -23,37 +23,17 @@ struct Caption(String);
 
 #[element]
 pub struct Label {
+    #[elem(patch = write_caption)]
     #[default(String::from("Label"))]
     pub text: String,
 }
 
-impl ElementVisual<Host> for Label {
-    fn build_fields(
-        &self,
-        build: &mut Build<BevyHost<NoTheme>, Self>,
-    ) {
-        let node = build.id();
-        let world = &mut *build.world;
-
-        world.entity_mut(node).insert(Caption(self.text.clone()));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost<NoTheme>>,
-        field: LabelField,
-    ) {
-        let node = patch.id();
-        let world = &mut *patch.world;
-
-        match field {
-            LabelField::Text => {
-                world
-                    .entity_mut(node)
-                    .insert(Caption(self.text.clone()));
-            }
-        }
-    }
+fn write_caption(patch: &mut Patch<FynixHost>, text: &str) {
+    let node = patch.id();
+    patch
+        .world
+        .entity_mut(node)
+        .insert(Caption(text.to_owned()));
 }
 
 /// The one child a build put under `root`.

--- a/crates/fynix/examples/field_ids.rs
+++ b/crates/fynix/examples/field_ids.rs
@@ -7,11 +7,40 @@
 //! Run with `cargo run -p fynix --example field_ids`.
 
 use fynix::element::{Fields, element};
+use fynix::host::Host;
 use fynix::lenz::FieldId;
+use fynix::ui::Patch;
+
+/// A stand-in backend: this example inspects field ids, never builds
+/// anything, so nothing here is ever called.
+pub struct FynixHost;
+
+impl Host for FynixHost {
+    type Node = usize;
+    type World = ();
+    type Theme = ();
+    fn delta(_: &()) -> f32 {
+        0.0
+    }
+    fn spawn(_: &mut (), _: usize) -> usize {
+        0
+    }
+    fn exists(_: &(), _: usize) -> bool {
+        true
+    }
+    fn children(_: &(), _: usize) -> Vec<usize> {
+        Vec::new()
+    }
+    fn despawn(_: &mut (), _: usize) {}
+}
+
+fn noop<T>(_: &mut Patch<FynixHost>, _: &T) {}
 
 #[element]
 pub struct Label {
+    #[elem(patch = noop)]
     pub text: String,
+    #[elem(patch = noop)]
     pub size: u32,
 }
 
@@ -22,6 +51,7 @@ pub struct Pair {
     pub top: Label,
     #[elem(child)]
     pub bottom: Label,
+    #[elem(patch = noop)]
     pub gap: u32,
 }
 
@@ -30,6 +60,7 @@ pub struct Pair {
 pub struct Stack {
     #[elem(child)]
     pub top: Label,
+    #[elem(patch = noop)]
     pub gap: u32,
 }
 
@@ -62,6 +93,7 @@ impl Look for Light {}
 pub struct Themed<L: Look> {
     #[elem(child)]
     pub label: Label,
+    #[elem(patch = noop)]
     pub look: L,
 }
 

--- a/crates/fynix/src/elem.rs
+++ b/crates/fynix/src/elem.rs
@@ -21,6 +21,7 @@ use crate::elem;
 /// # use fynix::{elem, val};
 /// # use fynix::style::{Style, StyledElem};
 /// # use fynix::host::Host;
+/// # use fynix::element::ElementBase;
 /// # pub struct Backend;
 /// # impl Host for Backend {
 /// #     type Node = usize;
@@ -38,6 +39,10 @@ use crate::elem;
 ///
 /// #[derive(Default)]
 /// struct Label { text: String, size: u32, font: Font }
+///
+/// impl ElementBase<Backend> for Label {
+///     fn base(_theme: &()) -> Self { Self::default() }
+/// }
 ///
 /// struct Title;
 /// impl Style for Title {

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -1,25 +1,32 @@
-//! What a struct is as a piece of UI, in two halves.
+//! What a struct is as a piece of UI.
 //!
-//! [`ElementVisual`] is the half you write. It only sees the fields
-//! this element draws itself. [`Element`] is the half
-//! `#[element]` writes. It owns the `#[elem(child)]`
-//! children, builds them first, and walks down to them when a change
-//! names one.
+//! `#[element]` writes it all: the [`ElementBase`] the cascade starts
+//! from, and the [`Element`] that owns the `#[elem(child)]` children,
+//! builds them first, and walks down to them when a change names one.
+//! A field's own value writer and the optional structural hook are
+//! named by `#[elem(patch = ...)]` and `#[element(build = ...)]`.
 
 use crate::host::Host;
 use crate::lenz::FieldId;
 use crate::records::Records;
 use crate::store::Store;
-use crate::ui::{Build, Patch};
 
 /// Marks a struct as an element. See
 /// [`fynix_macros::element`](macro@fynix_macros::element).
 pub use fynix_macros::element;
 
+/// The value an element starts from, before a style and the call site.
+///
+/// Written by `#[element]`: the struct's `Default`, then each
+/// `#[elem(default = ...)]` override, with the backend's theme in hand.
+pub trait ElementBase<H: Host>: Sized {
+    fn base(theme: &H::Theme) -> Self;
+}
+
 /// An element and the `#[elem(child)]` children beneath it.
 ///
-/// Written by `#[element]`, once per backend.
-pub trait Element<H: Host>: ElementVisual<H> + Default {
+/// Written by `#[element]`, for one backend.
+pub trait Element<H: Host>: Fields {
     /// Build this element under `parent`, children and all.
     ///
     /// Each child's node is recorded in `records`, so
@@ -36,8 +43,7 @@ pub trait Element<H: Host>: ElementVisual<H> + Default {
     /// [`Cursor::hops`](crate::lenz::Cursor::hops) reports it.
     ///
     /// Walks down one hop per element until it reaches the field's
-    /// owner, then calls
-    /// [`patch_fields`](ElementVisual::patch_fields).
+    /// owner, then runs that field's `#[elem(patch = ...)]` writer.
     fn patch(
         &self,
         world: &mut H::World,
@@ -55,25 +61,6 @@ pub trait Element<H: Host>: ElementVisual<H> + Default {
         node: H::Node,
         store: &mut Store<H>,
     );
-}
-
-/// How an element draws its own fields on one backend.
-///
-/// Implemented by hand, once per struct and backend pair.
-pub trait ElementVisual<H: Host>: Fields {
-    /// Write this element's own fields onto `draw`'s own node.
-    ///
-    /// The node already exists, with its `#[elem(child)]` fields
-    /// already built under it. Reach one with [`Build::child`].
-    fn build_fields(&self, draw: &mut Build<H, Self>)
-    where
-        Self: Element<H> + Send + Sync;
-
-    /// Push one changed field into visuals that already exist.
-    ///
-    /// A plain struct field is written whole. Elements are reached
-    /// one hop at a time and never arrive here.
-    fn patch_fields(&self, patch: &mut Patch<H>, field: Self::Field);
 }
 
 /// A struct whose own fields can be named one by one.

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -11,6 +11,7 @@
 
 use core::marker::PhantomData;
 
+use crate::element::ElementBase;
 use crate::host::Host;
 
 /// A look, as a mutation of an element that already has its defaults.
@@ -21,6 +22,7 @@ use crate::host::Host;
 /// ```
 /// use fynix::style::{Style, StyledElem};
 /// # use fynix::host::Host;
+/// # use fynix::element::ElementBase;
 /// # pub struct Backend;
 /// # impl Host for Backend {
 /// #     type Node = usize;
@@ -35,6 +37,10 @@ use crate::host::Host;
 ///
 /// #[derive(Default)]
 /// pub struct Label { size: u32, weight: u32 }
+///
+/// impl ElementBase<Backend> for Label {
+///     fn base(_theme: &()) -> Self { Self::default() }
+/// }
 ///
 /// pub struct Heading { level: u32 }
 ///
@@ -61,7 +67,7 @@ pub trait Style {
     /// The backend it moves on. A style that only writes fields moves
     /// on all of them and says so with a parameter of its own.
     type Host: Host;
-    type Element: Default;
+    type Element: ElementBase<Self::Host>;
 
     /// Called once, so it consumes rather than borrows: a style
     /// meant to be applied more than once is implemented for `&Self`.
@@ -98,7 +104,8 @@ impl<S: Style> StyledElem for S {
     type Element = S::Element;
 
     fn create(self, theme: &<S::Host as Host>::Theme) -> S::Element {
-        let mut elem = S::Element::default();
+        let mut elem =
+            <S::Element as ElementBase<S::Host>>::base(theme);
         self.apply(&mut elem, theme);
 
         elem
@@ -186,7 +193,7 @@ impl<H, E> Default for NoStyle<H, E> {
     }
 }
 
-impl<H: Host, E: Default> Style for NoStyle<H, E> {
+impl<H: Host, E: ElementBase<H>> Style for NoStyle<H, E> {
     type Host = H;
     type Element = E;
 }

--- a/crates/fynix/src/ui.rs
+++ b/crates/fynix/src/ui.rs
@@ -49,8 +49,7 @@ impl<'a, H: Host> Ui<'a, H> {
     }
 
     /// The node these children are being built under, or the
-    /// element's own node from inside
-    /// [`build_fields`](crate::element::ElementVisual::build_fields).
+    /// element's own node from inside a `#[element(build = ...)]` hook.
     pub fn parent(&self) -> H::Node {
         self.parent
     }
@@ -119,10 +118,11 @@ impl<'a, H: Host> Ui<'a, H> {
     }
 }
 
-/// What [`build_fields`](crate::element::ElementVisual::build_fields)
-/// writes through: this element's own node, `world`, and `theme`.
+/// What a `#[element(build = ...)]` hook writes through: this
+/// element's own node, `world`, `theme`, and the store and lanes for
+/// wiring children and transitions.
 ///
-/// Not [`ElementMut`]: a node running its own `build_fields` has not
+/// Not [`ElementMut`]: a node running its own build hook has not
 /// finished existing yet, so `bind`/`watch`/`with` would not mean
 /// what they mean anywhere else.
 pub struct Build<'a, H: Host, E: Element<H>> {
@@ -193,10 +193,10 @@ impl<'a, H: Host, E: Element<H>> Build<'a, H, E> {
     }
 }
 
-/// What [`patch_fields`](crate::element::ElementVisual::patch_fields)
-/// writes through: the node a change landed on, `world`, and `theme`.
+/// What a `#[elem(patch = ...)]` writer writes through: the node the
+/// value lands on, `world`, and `theme`.
 ///
-/// No [`Store`]/[`Lanes`] here. A patch writes fields; it never wires
+/// No [`Store`]/[`Lanes`] here. A patch writes a value; it never wires
 /// a child or a lane.
 pub struct Patch<'a, H: Host> {
     pub world: &'a mut H::World,
@@ -378,10 +378,10 @@ impl<H: Host, E: Element<H>> ElementMut<'_, '_, H, E> {
         self
     }
 
-    /// As [`transition`](Self::transition), for
-    /// [`build_fields`](crate::element::ElementVisual::build_fields):
-    /// the element has no entry in the kernel's table yet, so `base`
-    /// is passed in rather than read back.
+    /// As [`transition`](Self::transition), for a
+    /// `#[element(build = ...)]` hook: the element has no entry in the
+    /// kernel's table yet, so `base` is passed in rather than read
+    /// back.
     pub fn transition_from<P>(
         &mut self,
         field: impl FnOnce(Cursor<Identity<E>>) -> Cursor<P>,

--- a/crates/fynix/tests/common/mod.rs
+++ b/crates/fynix/tests/common/mod.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code)]
 
 use fynix::Fynix;
-use fynix::element::{Element, ElementVisual, element};
+use fynix::element::{Element, element};
 use fynix::host::Host;
 use fynix::lenz::{Cursor, FieldPath, Identity};
 use fynix::ui::{Build, ElementMut, Patch};
@@ -24,7 +24,7 @@ pub enum Interact {
 
 /// What a backend does when an interaction fires: point a lane
 /// somewhere. Only needs the kernel, since [`Fynix::aim`] does too.
-type Aim = Box<dyn Fn(&mut Fynix<Backend>) + Send + Sync>;
+type Aim = Box<dyn Fn(&mut Fynix<FynixHost>) + Send + Sync>;
 
 /// The `aim_on` a real backend would build for itself, over whatever
 /// events it actually has. This one is a stand-in for a pointer.
@@ -40,8 +40,8 @@ pub trait TestAim<E> {
         P::Target: Clone + Send + Sync;
 }
 
-impl<E: Element<Backend>> TestAim<E>
-    for ElementMut<'_, '_, Backend, E>
+impl<E: Element<FynixHost>> TestAim<E>
+    for ElementMut<'_, '_, FynixHost, E>
 {
     fn aim_on<P>(
         &mut self,
@@ -57,7 +57,7 @@ impl<E: Element<Backend>> TestAim<E>
         self.ui.world.interactions.push((
             node,
             on,
-            Box::new(move |kernel: &mut Fynix<Backend>| {
+            Box::new(move |kernel: &mut Fynix<FynixHost>| {
                 kernel.aim(node, field, target.clone());
             }),
         ));
@@ -65,10 +65,10 @@ impl<E: Element<Backend>> TestAim<E>
     }
 }
 
-/// As above, from [`build_fields`](ElementVisual::build_fields):
-/// [`Build`] carries `world` directly rather than through a [`Ui`], but
-/// otherwise wires the same interaction the same way.
-impl<E: Element<Backend>> TestAim<E> for Build<'_, Backend, E> {
+/// As above, from a `#[element(build = ...)]` hook: [`Build`] carries
+/// `world` directly rather than through a [`Ui`], but otherwise wires
+/// the same interaction the same way.
+impl<E: Element<FynixHost>> TestAim<E> for Build<'_, FynixHost, E> {
     fn aim_on<P>(
         &mut self,
         on: Interact,
@@ -83,7 +83,7 @@ impl<E: Element<Backend>> TestAim<E> for Build<'_, Backend, E> {
         self.world.interactions.push((
             node,
             on,
-            Box::new(move |kernel: &mut Fynix<Backend>| {
+            Box::new(move |kernel: &mut Fynix<FynixHost>| {
                 kernel.aim(node, field, target.clone());
             }),
         ));
@@ -154,7 +154,7 @@ impl World {
     /// hear about it.
     pub fn interact(
         &mut self,
-        kernel: &mut Fynix<Backend>,
+        kernel: &mut Fynix<FynixHost>,
         node: usize,
         on: Interact,
     ) {
@@ -172,9 +172,9 @@ impl World {
     }
 }
 
-pub struct Backend;
+pub struct FynixHost;
 
-impl Host for Backend {
+impl Host for FynixHost {
     type Node = usize;
     type World = World;
     /// Nothing in these tests reads a theme.
@@ -219,36 +219,22 @@ impl Host for Backend {
 
 /// The default is what a test gets when it only cares that a label is
 /// there, so nothing has to spell one out.
-#[element]
+#[element(host = FynixHost)]
 pub struct Label {
+    #[elem(patch = write_label_text)]
     #[default(String::from("Label"))]
     pub text: String,
+    #[elem(patch = write_label_size)]
     #[default(13)]
     pub size: u32,
 }
 
-impl ElementVisual<Backend> for Label {
-    fn build_fields(&self, draw: &mut Build<Backend, Self>) {
-        let node = draw.id();
-        let world = &mut *draw.world;
+fn write_label_text(patch: &mut Patch<FynixHost>, text: &str) {
+    let node = patch.id();
+    patch.world.node(node).text = text.to_owned();
+}
 
-        world.node(node).text = self.text.clone();
-        world.node(node).size = self.size;
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<Backend>,
-        field: LabelField,
-    ) {
-        let node = patch.id();
-        let world = &mut *patch.world;
-
-        match field {
-            LabelField::Text => {
-                world.node(node).text = self.text.clone()
-            }
-            LabelField::Size => world.node(node).size = self.size,
-        }
-    }
+fn write_label_size(patch: &mut Patch<FynixHost>, size: &u32) {
+    let node = patch.id();
+    patch.world.node(node).size = *size;
 }

--- a/crates/fynix/tests/elements.rs
+++ b/crates/fynix/tests/elements.rs
@@ -3,22 +3,23 @@
 
 mod common;
 
-use common::{Backend, Label, LabelCursor, World};
-use fynix::element::{Element, ElementVisual, Fields, element};
+use common::{FynixHost, Label, LabelCursor, World};
+use fynix::element::{Element, Fields, element};
 use fynix::host::Host;
-use fynix::lenz::FieldPath;
+use fynix::lenz::{FieldPath, Lenz};
 use fynix::records::Records;
-use fynix::ui::{Build, Patch};
+use fynix::ui::Patch;
 
 #[element]
 pub struct Icon {
+    #[elem(patch = write_glyph)]
     #[default('+')]
     pub glyph: char,
 }
 
 /// Plain data, not an element: no node of its own, so `Button` draws
 /// it.
-#[element]
+#[derive(Debug, Default, Lenz)]
 pub struct Border {
     pub width: u32,
     pub radius: u32,
@@ -33,65 +34,29 @@ pub struct Button {
     #[elem(child)]
     #[default(..)]
     pub icon: Option<Icon>,
+    #[elem(patch = write_padding)]
     #[default(4)]
     pub padding: u32,
+    #[elem(patch = write_border)]
     pub border: Border,
 }
 
-impl ElementVisual<Backend> for Icon {
-    fn build_fields(&self, build: &mut Build<common::Backend, Self>) {
-        let node = build.id();
-        let world = &mut *build.world;
-
-        world.node(node).glyph = self.glyph;
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<Backend>,
-        field: IconField,
-    ) {
-        let node = patch.id();
-        let world = &mut *patch.world;
-
-        match field {
-            IconField::Glyph => world.node(node).glyph = self.glyph,
-        }
-    }
+fn write_glyph(patch: &mut Patch<FynixHost>, glyph: &char) {
+    let node = patch.id();
+    patch.world.node(node).glyph = *glyph;
 }
 
-impl ElementVisual<Backend> for Button {
-    /// Only what `Button` draws. Nothing here mentions `label` or
-    /// `icon`: the derive builds and patches those.
-    fn build_fields(&self, build: &mut Build<common::Backend, Self>) {
-        let node = build.id();
-        let world = &mut *build.world;
+fn write_padding(patch: &mut Patch<FynixHost>, padding: &u32) {
+    let node = patch.id();
+    patch.world.node(node).padding = *padding;
+}
 
-        world.node(node).padding = self.padding;
-        world.node(node).border_width = self.border.width;
-        world.node(node).border_radius = self.border.radius;
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<Backend>,
-        field: ButtonField,
-    ) {
-        let node = patch.id();
-        let world = &mut *patch.world;
-
-        match field {
-            ButtonField::Padding => {
-                world.node(node).padding = self.padding
-            }
-            // Plain data, so it goes on whole. Only elements are
-            // worth reaching into one field at a time.
-            ButtonField::Border => {
-                world.node(node).border_width = self.border.width;
-                world.node(node).border_radius = self.border.radius;
-            }
-        }
-    }
+/// Plain data, so it goes on whole. Only elements are worth reaching
+/// into one field at a time.
+fn write_border(patch: &mut Patch<FynixHost>, border: &Border) {
+    let node = patch.id();
+    patch.world.node(node).border_width = border.width;
+    patch.world.node(node).border_radius = border.radius;
 }
 
 #[test]
@@ -221,11 +186,11 @@ fn despawn_takes_the_children_and_their_entries() {
 
     button.despawn(&mut world, node, records.store_mut());
 
-    assert!(!Backend::exists(&world, node));
-    assert!(!Backend::exists(&world, label));
-    assert!(!Backend::exists(&world, icon));
+    assert!(!FynixHost::exists(&world, node));
+    assert!(!FynixHost::exists(&world, label));
+    assert!(!FynixHost::exists(&world, icon));
     assert!(records.store().is_empty());
-    assert!(Backend::exists(&world, parent));
+    assert!(FynixHost::exists(&world, parent));
 }
 
 #[test]
@@ -238,7 +203,7 @@ fn pruning_drops_what_the_app_despawned() {
     assert_eq!(records.store().len(), 2);
 
     // Behind our back, so nothing cleared the store as it went.
-    Backend::despawn(&mut world, node);
+    FynixHost::despawn(&mut world, node);
     records.store_mut().prune(&world);
 
     assert!(records.store().is_empty());

--- a/crates/fynix/tests/generics.rs
+++ b/crates/fynix/tests/generics.rs
@@ -3,15 +3,13 @@
 
 mod common;
 
-use common::{Label, LabelCursor, World};
-use fynix::element::{Element, ElementVisual, Fields, element};
+use common::{FynixHost, Label, LabelCursor, World};
+use fynix::element::{Element, Fields, element};
 use fynix::records::Records;
-use fynix::ui::{Build, Patch};
+use fynix::ui::Patch;
 
-/// `Default`, so an element generic over its look has one too.
-/// `Send`/`Sync` too, since `Themed<L>` is an `Element`, and
-/// `build_fields` takes one by `Build`, which asks the same of every
-/// element it names.
+/// `Default`, so an element generic over its look starts from one.
+/// `Send`/`Sync` too, since `Themed<L>` is an `Element`.
 pub trait Look: Default + Send + Sync + 'static {
     fn glyph(&self) -> char;
 }
@@ -29,31 +27,13 @@ impl Look for Dark {
 pub struct Themed<L: Look> {
     #[elem(child)]
     pub label: Label,
+    #[elem(patch = write_look::<L>)]
     pub look: L,
 }
 
-impl<L: Look> ElementVisual<common::Backend> for Themed<L> {
-    fn build_fields(&self, build: &mut Build<common::Backend, Self>) {
-        let node = build.id();
-        let world = &mut *build.world;
-
-        world.node(node).glyph = self.look.glyph();
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<common::Backend>,
-        field: ThemedField,
-    ) {
-        let node = patch.id();
-        let world = &mut *patch.world;
-
-        match field {
-            ThemedField::Look => {
-                world.node(node).glyph = self.look.glyph()
-            }
-        }
-    }
+fn write_look<L: Look>(patch: &mut Patch<FynixHost>, look: &L) {
+    let node = patch.id();
+    patch.world.node(node).glyph = look.glyph();
 }
 
 #[test]

--- a/crates/fynix/tests/kernel.rs
+++ b/crates/fynix/tests/kernel.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{Backend, Label, LabelCursor, World};
+use common::{FynixHost, Label, LabelCursor, World};
 use fynix::Fynix;
 use fynix::WorldNodeRef;
 use fynix::elem;
@@ -11,7 +11,7 @@ use fynix::host::Host;
 
 /// Fires on the first call and never again, the way a bootstrap
 /// build does. A stateful predicate consumes its own signal.
-fn once() -> impl for<'w> FnMut(WorldNodeRef<'w, Backend>) -> bool
+fn once() -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -21,7 +21,7 @@ fn once() -> impl for<'w> FnMut(WorldNodeRef<'w, Backend>) -> bool
 
 /// The one child a watcher built under `root`.
 fn only_child(world: &World, root: usize) -> usize {
-    let children = Backend::children(world, root);
+    let children = FynixHost::children(world, root);
     assert_eq!(children.len(), 1, "one element was built");
     children[0]
 }
@@ -64,11 +64,11 @@ fn watch_builds_nothing_when_its_predicate_never_fires() {
         &mut world,
     );
 
-    assert!(Backend::children(&world, root).is_empty());
+    assert!(FynixHost::children(&world, root).is_empty());
 
     kernel.flush(&mut world);
 
-    assert!(Backend::children(&world, root).is_empty());
+    assert!(FynixHost::children(&world, root).is_empty());
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn rebuild_replaces_the_children() {
     // set below.
     kernel.watch(
         root,
-        |WorldNodeRef { world, .. }: WorldNodeRef<Backend>| {
+        |WorldNodeRef { world, .. }: WorldNodeRef<FynixHost>| {
             world.source.changed
         },
         |ui| {
@@ -153,7 +153,7 @@ fn rebuild_replaces_the_children() {
         },
         &mut world,
     );
-    assert!(Backend::children(&world, root).is_empty());
+    assert!(FynixHost::children(&world, root).is_empty());
 
     world.source.changed = true;
     kernel.flush(&mut world);
@@ -165,7 +165,7 @@ fn rebuild_replaces_the_children() {
     // The old subtree went, rather than a second one appearing
     // beside it.
     assert_ne!(first, second, "rebuilt, not added to");
-    assert!(!Backend::exists(&world, first));
+    assert!(!FynixHost::exists(&world, first));
     assert_eq!(world.get(second).text, "Label");
 }
 
@@ -193,14 +193,14 @@ fn dead_node_is_not_patched() {
 
     // Despawned behind the kernel's back. A binding kept against a
     // dead handle would patch a node the host has already freed.
-    Backend::despawn(&mut world, label);
+    FynixHost::despawn(&mut world, label);
 
     world.source.text = "Saved".into();
     world.source.changed = true;
     kernel.flush(&mut world);
 
-    assert!(!Backend::exists(&world, label));
-    assert!(Backend::exists(&world, root));
+    assert!(!FynixHost::exists(&world, label));
+    assert!(FynixHost::exists(&world, root));
 }
 
 #[test]
@@ -212,7 +212,7 @@ fn swept_node_takes_its_element_with_it() {
     // set below.
     kernel.watch(
         root,
-        |WorldNodeRef { world, .. }: WorldNodeRef<Backend>| {
+        |WorldNodeRef { world, .. }: WorldNodeRef<FynixHost>| {
             world.source.changed
         },
         |ui| {
@@ -235,7 +235,7 @@ fn swept_node_takes_its_element_with_it() {
     // Nothing to rebuild it now, so the last one goes too.
     world.source.changed = false;
     let last = only_child(&world, root);
-    Backend::despawn(&mut world, last);
+    FynixHost::despawn(&mut world, last);
     kernel.flush(&mut world);
 
     assert_eq!(kernel.element_len(), 0);
@@ -248,7 +248,7 @@ fn dead_root_takes_its_watcher_with_it() {
 
     // Under the root, so the watcher's own root can be despawned
     // without taking the whole world with it.
-    let branch = Backend::spawn(&mut world, root);
+    let branch = FynixHost::spawn(&mut world, root);
 
     kernel.watch(
         branch,
@@ -263,7 +263,7 @@ fn dead_root_takes_its_watcher_with_it() {
     kernel.flush(&mut world);
     assert_eq!(kernel.watcher_len(), 1, "its root is still there");
 
-    Backend::despawn(&mut world, branch);
+    FynixHost::despawn(&mut world, branch);
     kernel.flush(&mut world);
 
     assert_eq!(kernel.watcher_len(), 0, "nothing left to rebuild");
@@ -292,7 +292,7 @@ fn dead_node_takes_its_bindings_with_it() {
     let label = only_child(&world, root);
     assert_eq!(kernel.binding_len(), 1);
 
-    Backend::despawn(&mut world, label);
+    FynixHost::despawn(&mut world, label);
     kernel.flush(&mut world);
 
     assert_eq!(kernel.binding_len(), 0, "the binding went with it");

--- a/crates/fynix/tests/siblings.rs
+++ b/crates/fynix/tests/siblings.rs
@@ -3,10 +3,10 @@
 
 mod common;
 
-use common::{Label, LabelCursor, World};
-use fynix::element::{Element, ElementVisual, element};
+use common::{FynixHost, Label, LabelCursor, World};
+use fynix::element::{Element, element};
 use fynix::records::Records;
-use fynix::ui::{Build, Patch};
+use fynix::ui::Patch;
 
 /// Two labels that already say which is which, so a test can tell one
 /// node from the other without setting anything up.
@@ -18,30 +18,14 @@ pub struct Pair {
     #[elem(child)]
     #[default(text: String::from("down"), size: 2)]
     pub bottom: Label,
+    #[elem(patch = write_gap)]
     #[default(7)]
     pub gap: u32,
 }
 
-impl ElementVisual<common::Backend> for Pair {
-    fn build_fields(&self, build: &mut Build<common::Backend, Self>) {
-        let node = build.id();
-        let world = &mut *build.world;
-
-        world.node(node).padding = self.gap;
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<common::Backend>,
-        field: PairField,
-    ) {
-        let node = patch.id();
-        let world = &mut *patch.world;
-
-        match field {
-            PairField::Gap => world.node(node).padding = self.gap,
-        }
-    }
+fn write_gap(patch: &mut Patch<FynixHost>, gap: &u32) {
+    let node = patch.id();
+    patch.world.node(node).padding = *gap;
 }
 
 #[test]

--- a/crates/fynix/tests/styles.rs
+++ b/crates/fynix/tests/styles.rs
@@ -8,9 +8,9 @@ use core::marker::PhantomData;
 
 mod common;
 
-use common::{Backend, Label, World};
+use common::{FynixHost, Label, World};
 use fynix::Fynix;
-use fynix::element::Element;
+use fynix::element::{Element, ElementBase};
 use fynix::host::Host;
 use fynix::records::Records;
 use fynix::style::{Raw, Style, StyledElem};
@@ -19,7 +19,7 @@ use fynix::{elem, val};
 /// What the cascade produced, for a test that only wants the value.
 /// `create` says nothing about a backend, but the type it is called on
 /// has to name one.
-fn create<S: StyledElem<Host = Backend>>(styled: S) -> S::Element {
+fn create<S: StyledElem<Host = FynixHost>>(styled: S) -> S::Element {
     styled.create(&())
 }
 
@@ -27,7 +27,7 @@ fn create<S: StyledElem<Host = Backend>>(styled: S) -> S::Element {
 struct Title;
 
 impl Style for Title {
-    type Host = Backend;
+    type Host = FynixHost;
     type Element = Label;
 
     fn apply(self, label: &mut Label, _theme: &()) {
@@ -63,7 +63,7 @@ fn the_style_can_be_any_expression() {
     struct Exactly(u32);
 
     impl Style for Exactly {
-        type Host = Backend;
+        type Host = FynixHost;
         type Element = Label;
 
         fn apply(self, label: &mut Label, _theme: &()) {
@@ -88,13 +88,19 @@ fn generic_elements_and_styles_both_carry_their_arguments() {
         look: L,
     }
 
+    impl<L: Default> ElementBase<FynixHost> for Themed<L> {
+        fn base(_theme: &()) -> Self {
+            Self::default()
+        }
+    }
+
     #[derive(Default, Debug, PartialEq)]
     struct Dark;
 
     struct Wide<L>(PhantomData<fn() -> L>);
 
     impl<L: Default> Style for Wide<L> {
-        type Host = Backend;
+        type Host = FynixHost;
         type Element = Themed<L>;
 
         fn apply(self, themed: &mut Themed<L>, _theme: &()) {
@@ -135,10 +141,16 @@ fn field_paths_reach_as_deep_as_they_go() {
         font: Font,
     }
 
+    impl ElementBase<FynixHost> for Card {
+        fn base(_theme: &()) -> Self {
+            Self::default()
+        }
+    }
+
     struct Wide;
 
     impl Style for Wide {
-        type Host = Backend;
+        type Host = FynixHost;
         type Element = Card;
 
         fn apply(self, card: &mut Card, _theme: &()) {
@@ -192,7 +204,7 @@ fn what_the_cascade_left_is_what_gets_built() {
     let mut records = Records::default();
 
     let label = create(elem!(!Title, text = "Save"));
-    let node = Element::<Backend>::build(
+    let node = Element::<FynixHost>::build(
         &label,
         &mut world,
         parent,
@@ -218,7 +230,7 @@ fn the_builder_takes_a_styled_element_whole() {
         &mut world,
     );
 
-    let children = Backend::children(&world, root);
+    let children = FynixHost::children(&world, root);
     assert_eq!(world.get(children[0]).text, "Save");
     assert_eq!(world.get(children[0]).size, 10);
 }

--- a/crates/fynix/tests/transitions.rs
+++ b/crates/fynix/tests/transitions.rs
@@ -4,8 +4,10 @@
 
 mod common;
 
-use common::{Backend, Interact, Label, LabelCursor, TestAim, World};
-use fynix::element::{ElementVisual, element};
+use common::{
+    FynixHost, Interact, Label, LabelCursor, TestAim, World,
+};
+use fynix::element::element;
 use fynix::host::Host;
 use fynix::style::Style;
 use fynix::transition::Transition;
@@ -15,7 +17,7 @@ use motiongfx_interp::ease;
 use motiongfx_interp::interpolation::Interpolation;
 
 /// Fires on the first flush and never again.
-fn once() -> impl for<'w> FnMut(WorldNodeRef<'w, Backend>) -> bool
+fn once() -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -24,14 +26,14 @@ fn once() -> impl for<'w> FnMut(WorldNodeRef<'w, Backend>) -> bool
 }
 
 fn only_child(world: &World, root: usize) -> usize {
-    let children = Backend::children(world, root);
+    let children = FynixHost::children(world, root);
     assert_eq!(children.len(), 1, "one element was built");
     children[0]
 }
 
 /// A label whose size travels over a second, and the world it is in.
 /// The delta is a quarter of that, so a flush is a quarter of the way.
-fn travelling() -> (World, usize, Fynix<Backend>, usize) {
+fn travelling() -> (World, usize, Fynix<FynixHost>, usize) {
     let (mut world, root) = World::with_root();
     world.delta = 0.25;
     let mut kernel = Fynix::new(());
@@ -150,60 +152,46 @@ fn style_carries_what_moves_as_well_as_what_it_looks_like() {
     /// element's own business - `Grower` leaves a slot for a style to
     /// fill, and wires the lane itself once it has a node to put it
     /// on.
-    #[element]
+    #[element(build = Self::build)]
     pub struct Grower {
+        #[elem(patch = write_text)]
         #[default(String::from("Label"))]
         pub text: String,
+        #[elem(patch = write_size)]
         #[default(13)]
         pub size: u32,
         /// What a style asks this to grow to under the pointer, if
-        /// anything.
+        /// anything. Read once, when the lane is wired.
+        #[elem(ignore)]
         pub grows_to: Option<u32>,
     }
 
-    impl ElementVisual<Backend> for Grower {
-        fn build_fields(&self, build: &mut Build<Backend, Self>) {
-            let node = build.id();
-            build.world.node(node).text = self.text.clone();
-            build.world.node(node).size = self.size;
+    fn write_text(patch: &mut Patch<FynixHost>, text: &str) {
+        let node = patch.id();
+        patch.world.node(node).text = text.to_owned();
+    }
 
-            if let Some(target) = self.grows_to {
-                build
-                    .transition_from(
-                        |g| g.size(),
-                        self.size,
-                        Transition::secs(
-                            1.0,
-                            <u32 as Interpolation<()>>::interp,
-                        ),
-                    )
-                    .aim_on(
-                        Interact::Enter,
-                        |g| g.size(),
-                        Some(target),
-                    )
-                    .aim_on(Interact::Leave, |g| g.size(), None);
-            }
-        }
+    fn write_size(patch: &mut Patch<FynixHost>, size: &u32) {
+        let node = patch.id();
+        patch.world.node(node).size = *size;
+    }
 
-        fn patch_fields(
-            &self,
-            patch: &mut Patch<Backend>,
-            field: GrowerField,
-        ) {
-            let node = patch.id();
-            let world = &mut *patch.world;
-
-            match field {
-                GrowerField::Text => {
-                    world.node(node).text = self.text.clone()
-                }
-                GrowerField::Size => {
-                    world.node(node).size = self.size
-                }
-                // Read once, at build - see build_fields.
-                GrowerField::GrowsTo => {}
-            }
+    impl Grower {
+        fn build(&self, build: &mut Build<FynixHost, Self>) {
+            let Some(target) = self.grows_to else {
+                return;
+            };
+            build
+                .transition_from(
+                    |g| g.size(),
+                    self.size,
+                    Transition::secs(
+                        1.0,
+                        <u32 as Interpolation<()>>::interp,
+                    ),
+                )
+                .aim_on(Interact::Enter, |g| g.size(), Some(target))
+                .aim_on(Interact::Leave, |g| g.size(), None);
         }
     }
 
@@ -212,7 +200,7 @@ fn style_carries_what_moves_as_well_as_what_it_looks_like() {
     struct Grows;
 
     impl Style for Grows {
-        type Host = Backend;
+        type Host = FynixHost;
         type Element = Grower;
 
         fn apply(self, grower: &mut Grower, _theme: &()) {
@@ -254,7 +242,7 @@ fn lane_goes_with_the_node_it_was_declared_on() {
 
     assert_eq!(kernel.lane_len(), 1);
 
-    Backend::despawn(&mut world, label);
+    FynixHost::despawn(&mut world, label);
     kernel.flush(&mut world);
 
     assert_eq!(kernel.lane_len(), 0);

--- a/crates/fynix_macros/src/element.rs
+++ b/crates/fynix_macros/src/element.rs
@@ -1,14 +1,113 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, Field, parse_quote};
+use syn::{
+    Data, DeriveInput, Expr, Field, Path, parse_quote,
+    punctuated::Punctuated,
+};
 
 use crate::common::{
     crate_path, generics, named_fields, option_inner, pascal_case,
     snake_case,
 };
 
-pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
+/// What `#[element(...)]` carries: the backend to build against and an
+/// optional structural hook.
+///
+/// `build` holds whatever expression `#[element(build = ...)]` names -
+/// a free `fn(&Self, &mut Build)`, or `Self::build` for the element's
+/// own inherent method.
+pub struct ElementArgs {
+    pub host: Path,
+    pub build: Option<Expr>,
+}
+
+impl ElementArgs {
+    pub fn parse(args: TokenStream2) -> syn::Result<Self> {
+        let mut host: Option<Path> = None;
+        let mut build: Option<Expr> = None;
+
+        if !args.is_empty() {
+            let parser = syn::meta::parser(|meta| {
+                if meta.path.is_ident("host") {
+                    host = Some(meta.value()?.parse()?);
+                    Ok(())
+                } else if meta.path.is_ident("build") {
+                    build = Some(meta.value()?.parse()?);
+                    Ok(())
+                } else {
+                    Err(meta.error("expected `host` or `build`"))
+                }
+            });
+            syn::parse::Parser::parse2(parser, args)?;
+        }
+
+        Ok(Self {
+            host: host
+                .unwrap_or_else(|| parse_quote!(crate::FynixHost)),
+            build,
+        })
+    }
+}
+
+/// What `#[elem(...)]` says about one field.
+#[derive(Default)]
+struct FieldConfig {
+    child: bool,
+    ignore: bool,
+    patch: Option<Expr>,
+    default: Option<Expr>,
+}
+
+fn field_config(field: &Field) -> syn::Result<FieldConfig> {
+    let mut cfg = FieldConfig::default();
+
+    for attr in &field.attrs {
+        if !attr.path().is_ident("elem") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("child") {
+                cfg.child = true;
+            } else if meta.path.is_ident("ignore") {
+                cfg.ignore = true;
+            } else if meta.path.is_ident("patch") {
+                cfg.patch = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("default") {
+                cfg.default = Some(meta.value()?.parse()?);
+            } else {
+                return Err(meta.error(
+                    "expected `child`, `ignore`, `patch = ...`, or \
+                     `default = ...`",
+                ));
+            }
+            Ok(())
+        })?;
+    }
+
+    if cfg.child && (cfg.ignore || cfg.patch.is_some()) {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`#[elem(child)]` takes no other directive",
+        ));
+    }
+    if cfg.ignore && cfg.patch.is_some() {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`#[elem(ignore)]` and `#[elem(patch)]` are exclusive",
+        ));
+    }
+
+    Ok(cfg)
+}
+
+pub fn expand(
+    args: TokenStream2,
+    ast: &DeriveInput,
+) -> syn::Result<TokenStream2> {
     let root = crate_path();
+    let opts = ElementArgs::parse(args)?;
+    let host = &opts.host;
+
     let name = &ast.ident;
     let fields = named_fields(ast, "element")?;
 
@@ -21,27 +120,39 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
     let path_mod = format_ident!("{}_path", snake_case(name));
     let field_enum = format_ident!("{}Field", name);
 
+    let host_node = quote!(<#host as #root::host::Host>::Node);
+    let host_world = quote!(<#host as #root::host::Host>::World);
+    let host_theme = quote!(<#host as #root::host::Host>::Theme);
+
     let mut variants = Vec::new();
     let mut ids = Vec::new();
     let mut lookups = Vec::new();
 
     let mut elem_bounds = Vec::new();
     let mut builds = Vec::new();
-    let mut patches = Vec::new();
+    let mut child_patches = Vec::new();
+    let mut own_patches = Vec::new();
+    let mut field_writes = Vec::new();
     let mut despawns = Vec::new();
+    let mut default_overrides = Vec::new();
 
     for field in fields.iter() {
         let field_name =
             field.ident.as_ref().expect("named fields checked above");
+        let cfg = field_config(field)?;
+
         let marker = quote!(#path_mod::#field_name #ty);
         let id = quote!(<#marker as #root::lenz::FieldPath>::id());
 
-        // A field marked `#[elem(child)]` is an element in its own
-        // right. It is absent from the enum, because naming it there
-        // would offer a second, redundant way in.
-        if is_child(field)? {
-            // `Option<T>` builds nothing when absent, so the store
-            // simply has no entry and the walk stops there.
+        if let Some(default) = &cfg.default {
+            default_overrides
+                .push(quote!(__elem.#field_name = #default;));
+        }
+
+        // A `#[elem(child)]` field is an element in its own right. It
+        // is absent from the enum: naming it there would offer a
+        // second, redundant way in.
+        if cfg.child {
             let (elem_ty, elem) = match option_inner(&field.ty) {
                 Some(inner) => {
                     (inner, quote!(self.#field_name.as_ref()))
@@ -52,13 +163,13 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
                 ),
             };
 
-            elem_bounds
-                .push(quote!(#elem_ty: #root::element::Element<H>));
+            elem_bounds.push(
+                quote!(#elem_ty: #root::element::Element<#host>),
+            );
 
-            // Fully qualified throughout, so a user of the derive
-            // need not have our traits in scope.
-            let as_elem =
-                quote!(<#elem_ty as #root::element::Element<H>>);
+            let as_elem = quote!(
+                <#elem_ty as #root::element::Element<#host>>
+            );
 
             builds.push(quote! {
                 if let ::core::option::Option::Some(elem) = #elem {
@@ -69,7 +180,7 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
                 }
             });
 
-            patches.push(quote! {
+            child_patches.push(quote! {
                 if *head == #id {
                     if let (
                         ::core::option::Option::Some(elem),
@@ -97,19 +208,23 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
             continue;
         }
 
-        // A field marked `#[elem(ignore)]` only ever changes at
-        // build. Leaving it out of the enum the same way `child` does
-        // makes that true rather than merely asked for: nothing can
-        // name it to walk a path there, so a stray `.bind()` writes
-        // the field and has no way to tell the backend. The struct is
-        // re-emitted with `#[lenz(ignore)]` in its place, so the
-        // cursor has no `.field()` for it either.
-        if is_ignore(field)? {
+        // A `#[elem(ignore)]` field only ever changes at build. It is
+        // left out of the enum and, through `#[lenz(ignore)]` on the
+        // re-emitted struct, out of the cursor: nothing can name a
+        // path there.
+        if cfg.ignore {
             continue;
         }
 
-        let variant = format_ident!("{}", pascal_case(field_name));
+        let Some(patch) = &cfg.patch else {
+            return Err(syn::Error::new_spanned(
+                field,
+                "an own field needs `#[elem(patch = ...)]` or \
+                 `#[elem(ignore)]`",
+            ));
+        };
 
+        let variant = format_ident!("{}", pascal_case(field_name));
         variants.push(quote!(#variant,));
         ids.push(quote!(#field_enum::#variant => #id,));
         lookups.push(quote! {
@@ -119,9 +234,40 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
                 );
             }
         });
+
+        field_writes.push(quote! {
+            {
+                let mut __patch = #root::ui::Patch::new(
+                    world, node, theme,
+                );
+                (#patch)(&mut __patch, &self.#field_name);
+            }
+        });
+
+        own_patches.push(quote! {
+            if *head == #id {
+                let mut __patch = #root::ui::Patch::new(
+                    world, node, theme,
+                );
+                (#patch)(&mut __patch, &self.#field_name);
+                return;
+            }
+        });
     }
 
     let subject = rewrite_struct(ast, &root)?;
+
+    let build_hook = opts.build.map(|build_fn| {
+        quote! {
+            {
+                let (__lanes, __store) = records.build_parts();
+                let mut __draw = #root::ui::Build::new(
+                    world, node, __lanes, __store, theme,
+                );
+                (#build_fn)(self, &mut __draw);
+            }
+        }
+    });
 
     Ok(quote! {
         #subject
@@ -148,44 +294,52 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
             }
         }
 
-        impl<H, #decl> #root::element::Element<H> for #name #ty
+        impl<#decl> #root::element::ElementBase<#host> for #name #ty
         where
-            H: #root::host::Host,
-            Self: #root::element::ElementVisual<H>
-                + ::core::marker::Send
-                + ::core::marker::Sync,
+            Self: ::core::default::Default,
+            #predicates
+        {
+            fn base(theme: &#host_theme) -> Self {
+                let _ = theme;
+                let mut __elem =
+                    <Self as ::core::default::Default>::default();
+                #(#default_overrides)*
+                __elem
+            }
+        }
+
+        impl<#decl> #root::element::Element<#host> for #name #ty
+        where
+            Self: ::core::marker::Send + ::core::marker::Sync,
             #(#elem_bounds,)*
             #predicates
         {
             fn build(
                 &self,
-                world: &mut H::World,
-                parent: H::Node,
-                records: &mut #root::records::Records<H>,
-                theme: &H::Theme,
-            ) -> H::Node {
-                let node = <H as #root::host::Host>::spawn(
-                    world, parent,
-                );
+                world: &mut #host_world,
+                parent: #host_node,
+                records: &mut #root::records::Records<#host>,
+                theme: &#host_theme,
+            ) -> #host_node {
+                let node =
+                    <#host as #root::host::Host>::spawn(world, parent);
 
                 #(#builds)*
 
-                let (lanes, store) = records.build_parts();
-                let mut draw = #root::ui::Build::new(
-                    world, node, lanes, store, theme,
-                );
-                <Self as #root::element::ElementVisual<H>>
-                    ::build_fields(self, &mut draw);
+                #build_hook
+
+                #(#field_writes)*
+
                 node
             }
 
             fn patch(
                 &self,
-                world: &mut H::World,
-                node: H::Node,
+                world: &mut #host_world,
+                node: #host_node,
                 path: &[#root::lenz::FieldId],
-                store: &mut #root::store::Store<H>,
-                theme: &H::Theme,
+                store: &mut #root::store::Store<#host>,
+                theme: &#host_theme,
             ) {
                 let ::core::option::Option::Some((head, rest)) =
                     path.split_first()
@@ -193,40 +347,33 @@ pub fn expand(ast: &DeriveInput) -> syn::Result<TokenStream2> {
                     return;
                 };
 
-                #(#patches)*
+                #(#child_patches)*
 
-                // Whatever else the walk had in mind, this element
-                // draws the field whole.
+                // An own field is drawn whole, whatever else the walk
+                // had in mind.
                 let _ = rest;
 
-                if let ::core::option::Option::Some(field) =
-                    <Self as #root::element::Fields>::field(*head)
-                {
-                    let mut patch =
-                        #root::ui::Patch::new(world, node, theme);
-                    <Self as #root::element::ElementVisual<H>>
-                        ::patch_fields(self, &mut patch, field);
-                }
+                #(#own_patches)*
             }
 
             fn despawn(
                 &self,
-                world: &mut H::World,
-                node: H::Node,
-                store: &mut #root::store::Store<H>,
+                world: &mut #host_world,
+                node: #host_node,
+                store: &mut #root::store::Store<#host>,
             ) {
                 #(#despawns)*
-                <H as #root::host::Host>::despawn(world, node);
+                <#host as #root::host::Host>::despawn(world, node);
             }
         }
     })
 }
 
-/// The struct itself, re-emitted for the field/patch system to derive
-/// off: `#[elem(child)]` markers dropped, `#[elem(ignore)]` swapped
-/// for `#[lenz(ignore)]`, and `Lenz`/`OverrideDefault` derived - the
-/// dispatch below names a field by the id `Lenz` gives it, and an
-/// element's own fields almost always want `#[default(...)]`.
+/// The struct itself, re-emitted for the path system to derive off:
+/// `#[elem(...)]` markers dropped, `#[elem(ignore)]` swapped for
+/// `#[lenz(ignore)]`, and `Lenz`/`OverrideDefault` derived - the
+/// dispatch names a field by the id `Lenz` gives it, and `base` starts
+/// from the `Default` `OverrideDefault` writes.
 fn rewrite_struct(
     ast: &DeriveInput,
     root: &TokenStream2,
@@ -246,50 +393,19 @@ fn rewrite_struct(
     };
 
     for field in &mut data.fields {
-        let mut kept = Vec::with_capacity(field.attrs.len());
+        let cfg = field_config(field)?;
+        let mut kept: Punctuated<syn::Attribute, syn::Token![,]> =
+            Punctuated::new();
         for attr in field.attrs.drain(..) {
             if !attr.path().is_ident("elem") {
                 kept.push(attr);
-                continue;
-            }
-            match attr.parse_args::<syn::Ident>() {
-                Ok(directive) if directive == "child" => {}
-                Ok(directive) if directive == "ignore" => {
-                    kept.push(parse_quote!(#[lenz(ignore)]));
-                }
-                _ => {
-                    return Err(syn::Error::new_spanned(
-                        attr,
-                        "expected `#[elem(child)]` or \
-                         `#[elem(ignore)]`",
-                    ));
-                }
             }
         }
-        field.attrs = kept;
+        field.attrs = kept.into_iter().collect();
+        if cfg.ignore {
+            field.attrs.push(parse_quote!(#[lenz(ignore)]));
+        }
     }
 
     Ok(out)
-}
-
-/// What `#[elem(...)]` says about this field: `child` for one that is
-/// an element in its own right, `ignore` for one that only ever
-/// changes at build.
-fn elem_directive(field: &Field) -> syn::Result<Option<syn::Ident>> {
-    let Some(attr) =
-        field.attrs.iter().find(|attr| attr.path().is_ident("elem"))
-    else {
-        return Ok(None);
-    };
-    attr.parse_args::<syn::Ident>().map(Some)
-}
-
-fn is_child(field: &Field) -> syn::Result<bool> {
-    Ok(elem_directive(field)?
-        .is_some_and(|directive| directive == "child"))
-}
-
-fn is_ignore(field: &Field) -> syn::Result<bool> {
-    Ok(elem_directive(field)?
-        .is_some_and(|directive| directive == "ignore"))
 }

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -11,32 +11,32 @@ mod element;
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 
-/// Marks a struct as an element: the fields it draws itself become a
-/// dispatch enum a `match` can check for exhaustiveness, and the
-/// `#[elem(child)]` fields become children the tree builds first and
-/// walks down to when a change names one.
+/// Marks a struct as an element, built against one backend.
 ///
-/// The struct is re-emitted with `#[derive(Lenz, OverrideDefault)]`:
-/// the dispatch names a field by the id `Lenz` gives it, and an
-/// element's own fields almost always want `#[default(...)]`.
+/// The struct is re-emitted with `#[derive(Lenz, OverrideDefault)]`,
+/// then `Fields`, `ElementBase`, and `Element` are written for it. The
+/// backend is `crate::FynixHost` unless `#[element(host = <path>)]` names
+/// another.
 ///
+/// - `#[element(build = <fn>)]` - a structural hook run once at build,
+///   `fn(&Self, &mut Build<Host, Self>)`, that inserts components and
+///   wires lanes and interactions. `#[element(build = Self::build)]`
+///   points it at the element's own inherent `fn build`.
 /// - `#[elem(child)]` - a field that is an element in its own right.
-///   Absent from the enum; patches through its own id.
-/// - `#[elem(ignore)]` - a field that only ever changes at build.
-///   Absent from the enum and from the cursor, so nothing can name a
-///   path to it.
+///   Built first, walked into one hop at a time.
+/// - `#[elem(patch = <fn>)]` - an own field's value writer,
+///   `fn(&mut Patch<Host>, &FieldTy)`, given a reference to that one
+///   field. Run for every field at build and for the changed field on
+///   patch.
+/// - `#[elem(default = <expr>)]` - the value the field starts from,
+///   with `theme` in scope. Layered over the `#[default(...)]` the
+///   re-emitted struct still takes.
+/// - `#[elem(ignore)]` - a field no path can name; read only by the
+///   `build =` hook.
 #[proc_macro_attribute]
 pub fn element(args: TokenStream, input: TokenStream) -> TokenStream {
-    if !args.is_empty() {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "`#[element]` takes no arguments",
-        )
-        .into_compile_error()
-        .into();
-    }
     let ast = parse_macro_input!(input as DeriveInput);
-    match element::expand(&ast) {
+    match element::expand(args.into(), &ast) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.into_compile_error().into(),
     }

--- a/docs/reactive_dispatch_plan.md
+++ b/docs/reactive_dispatch_plan.md
@@ -1,0 +1,231 @@
+# Reactive dispatch: bindings and lanes without walking the tree
+
+Plan for the next round of `fynix` kernel work: cut the per-fire cost of
+a binding, and give transitions a backend that writes one component and
+never touches the retained element. Builds on the `#[element]` redesign
+(`nixon/moxie/fynix-patch`), where every field's writer became
+`fn(&mut Patch<H>, &FieldTy)` - the value is an argument now, not
+something read back off `&self`.
+
+## Where we are
+
+A binding stores a closure that runs on every `changed` fire
+(`ui.rs`, `ElementMut::bind`):
+
+1. `value(WorldNodeRef::new(world, node))` - read the new value.
+2. `elements.get_mut::<E>(&node)` - typed lookup into the retained
+   element table.
+3. `accessor.get_mut(element)` - walk the getter chain to the field,
+   hopping through `Option`s.
+4. `*field = new` - write it into the retained struct.
+5. `element.patch(world, node, &hops, store, theme)` - recurse one
+   `Element::patch` frame per child hop, then linear-scan the owner's
+   own-field `if *head == id` arms, then call that field's
+   `#[elem(patch = ...)]` writer with `&self.field`.
+
+A lane (`lanes.rs`, `Travel::advance`) does the same walk, plus a
+smuggle: it can't pass the animated value as an argument through the old
+path, so it does
+
+```rust
+let base = core::mem::replace(field, self.shown.clone());
+element.patch(world, node, &self.hops, store, theme);
+if let Some(field) = self.accessor.get_mut(element) { *field = base; }
+```
+
+writing `shown` into the struct, patching, then putting the base back.
+
+Every `changed` fire and every transition frame pays for steps 2, 3 and
+5. For a field bound three elements deep that is three virtual
+`Element::patch` calls and three re-scans, per frame, for a splitter
+drag or a playhead in motion.
+
+`Element::patch` has exactly two callers - `ui.rs` (bindings) and
+`lanes.rs` (lanes). Nothing else walks it.
+
+## The change
+
+### 1. Resolve a binding's target once
+
+The `hops` path is fixed for a binding's whole life. Resolve it at bind
+time instead of per fire:
+
+- Walk `store` (`store.child(node, id)` per hop) to the **owner node**.
+- Capture the terminal field's writer, `fn(&mut Patch<H>, &T)`.
+
+Store `(owner_node, writer)` on the `Binding`. The fire path becomes:
+
+```rust
+let new = value(WorldNodeRef::new(world, node));
+if let Some(el) = elements.get_mut::<E>(&node) {   // keep - see caveats
+    accessor.get_mut(el).map(|f| *f = new.clone());
+}
+let mut patch = Patch::new(world, owner_node, theme);
+(writer)(&mut patch, &new);
+```
+
+No recursion, no scan.
+
+**Getting the writer out of the cursor.** Since the `lenz` split the
+cursor and `FieldPath` are host-agnostic, so the `Patch<H>`-typed
+writer can't hang off them. Add a `fynix`-side trait the `#[element]`
+macro implements per field, on that field's terminal cursor segment:
+
+```rust
+pub trait OwnField<H: Host>: FieldPath {
+    fn write(patch: &mut Patch<H>, value: &Self::Target);
+}
+```
+
+`bind` bounds `P: OwnField<H>` and calls `P::write`. Composed hops
+expose the terminal field's impl, so `b.icon().color()` yields `Icon`'s
+`color` writer and the path to `Icon`'s node.
+
+### 2. A transition backend that never reads the element
+
+With an argument-taking writer the smuggle disappears. A lane holds its
+own state and pushes straight to the component:
+
+```rust
+struct Travel<H: Host, T> {
+    node: H::Node,
+    write: fn(&mut Patch<H>, &T),
+    transition: Transition<T>,
+    from: T,
+    shown: T,
+    heading: T,
+    target: Option<T>,
+    base: T,          // the lane's own copy of the resting value
+    elapsed: f32,
+}
+```
+
+`advance` loses its `elements` and `store` parameters and its
+`E: Element<H>` bound. The push is one line:
+
+```rust
+(self.write)(&mut Patch::new(world, node, theme), &self.shown);
+```
+
+**The base.** Today `advance` re-reads the base from the element every
+frame, because "the base can move mid flight". It moves only when a
+binding on the same field fires, and a structural rebuild tears the
+lane down, so: when a binding fires and `lanes` has an entry for
+`(node, field_id)`, it calls `lane.rebase(new)`. The lane carries its
+own `base: T`, seeded from the cascade value at creation
+(`insert_travel` already reads it there once).
+
+### 3. Trim `Element::patch`
+
+Once both callers are off it, the recursive own-field walk and the
+generated `patch` impl can go. Keep the child-hop dispatch only if
+something still needs a path walk; keep the `despawn` walk. `Fields` /
+the `*Field` enum stay - cursors and `field_id`/`field` still use them.
+
+## Caveats
+
+### The retained element is still a base-value store
+
+`Fynix::element(node)` is public and documented as "always reads the
+latest" - editor code and tests read field values back through it. If
+bindings stop writing the struct, that getter returns the cascade-time
+snapshot instead.
+
+Recommended: **keep the binding's `*field = new` write** (step 1 above
+keeps it). It is one move, it keeps `Fynix::element` honest, and it
+keeps the door open for anything else that reads the table. Only the
+`element.patch` *walk* is removed. Lanes never need the write - they
+don't own the base, they borrow a copy.
+
+The aggressive alternative - drop the struct write, let
+`Fynix::element` return the snapshot or delete it - is a separate
+decision, not required for the speedup.
+
+### Same-flush ordering: binding then lane
+
+A lane must re-assert every frame even when `shown` has not moved
+(today's `// Pushed even when unmoved` comment). A binding on the same
+field calls its writer earlier in the flush and puts the raw base on
+the component; the lane has to write after it. Flush order stays
+bindings, then lanes.
+
+### Cached node lifetime
+
+`(owner_node, writer)` is valid for the binding's or lane's life
+because a structural rebuild of the owning element recreates its
+bindings and lanes. This has to actually hold: if a binding can
+outlive a rebuild of an ancestor element, the cached node dangles.
+Confirm before shipping.
+
+### Missed rebase releases to a stale base
+
+If a binding fires without notifying a co-located lane, a later
+`aim(None)` animates the field back to the wrong resting value. The
+notify is a new invariant the binding path must not drop.
+
+### Mid-flight rebase semantics (unchanged)
+
+Aiming (`target = Some`) ignores the base. Releasing (`target = None`)
+heads to the current base. The rebase-notify keeps both, same as the
+live re-read does today.
+
+### Writers stay full-writes
+
+A writer runs once per field at build and again on each patch; given
+the same value it must land the same component state. Already true for
+every writer in `patch.rs`.
+
+## Pros and cons
+
+**Pros**
+
+- Binding fire drops from O(depth) virtual `patch` calls + O(fields)
+  scan to one component write.
+- Lane advance sheds the typed table lookup, the element borrow and the
+  walk - just an interpolation and a write. This is the per-frame path.
+- `Lane` stops depending on `Element`; `advance` sheds two parameters
+  and a bound. The trait gets small enough to reconsider boxing.
+- Transition correctness no longer rides on the replace/patch/restore
+  dance being exactly right.
+- `insert_travel` keeps its one-time base read; nothing reads the
+  element per frame any more.
+
+**Cons**
+
+- Macro work: emit `OwnField<H>` impls per field / terminal cursor
+  segment.
+- New invariant: a binding must `rebase` a co-located lane. A missed
+  call is a silent wrong-resting-value bug.
+- Bind-time cost moves up front: one `store` walk per binding. Net win
+  unless a binding is created and never fires.
+- A fn pointer and a node cached per binding and per lane - negligible.
+- Two dispatch paths coexist during migration until lanes move over.
+
+## Open questions
+
+- Does anything call `Element::patch` besides `ui.rs` and `lanes.rs`?
+  (Current grep: no.)
+- Besides `Fynix::element(node)`, who reads `records.elements`?
+  `Build::child` uses `store`, not the table - confirm nothing else in
+  the editor does.
+- Can a binding or lane outlive a rebuild of an ancestor element?
+- Does interaction/`aim` wiring touch the element, or only lanes and
+  the world?
+
+## Work items
+
+- [ ] `OwnField<H>` trait in `fynix`; `#[element]` emits impls per own
+      field.
+- [ ] Cursor exposes the terminal field's writer; `bind` resolves
+      `(owner_node, writer)` at bind time and stores it on `Binding`.
+- [ ] Binding fire path calls the writer directly; keep `*field = new`
+      for `Fynix::element`.
+- [ ] New `Travel` repr; `Lane::advance` drops `elements` / `store` /
+      the `Element` bound.
+- [ ] `Binding` -> `Lane` rebase notification keyed on
+      `(node, field_id)`.
+- [ ] Delete `Element::patch`'s own-field walk once both callers are
+      off it; keep child-hop only if still needed, keep `despawn`.
+- [ ] Audit `records.elements` readers; leave the table for
+      `Fynix::element` and despawn, out of the reactive path.
+- [ ] Bench a splitter drag and a playing timeline, before and after.

--- a/editor/moxie/src/ui/action.rs
+++ b/editor/moxie/src/ui/action.rs
@@ -24,7 +24,7 @@ use moxie_ui::elements::{
 use moxie_ui::inspector::{
     FieldRow, Source, inspect_value, reflect_changed,
 };
-use moxie_ui::reactive::{BevyHost, BevyUi, value_changed};
+use moxie_ui::reactive::{BevyUi, FynixHost, value_changed};
 
 use super::{PANEL_PADDING, hierarchy};
 use crate::{EditorScene, SelectedAction};
@@ -32,13 +32,13 @@ use crate::{EditorScene, SelectedAction};
 /// The action panel, as kernel nodes.
 pub(super) struct ActionPanel;
 
-impl Composer<BevyHost> for ActionPanel {
+impl Composer<FynixHost> for ActionPanel {
     type Element = ScrollArea;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, ScrollArea> {
+    ) -> ElementHandle<FynixHost, ScrollArea> {
         ui.elem(elem!(
             ScrollArea,
             flex_grow = 1.0f32,

--- a/editor/moxie/src/ui/assets.rs
+++ b/editor/moxie/src/ui/assets.rs
@@ -29,7 +29,7 @@ use moxie_ui::elements::{
     ButtonElem, Frame, Icon, Label, Panel, ScrollArea, TintButton,
 };
 use moxie_ui::fold::{CHEVRON_SHUT, Foldable, FoldsOn};
-use moxie_ui::reactive::{BevyHost, BevyUi, resource_changed};
+use moxie_ui::reactive::{BevyUi, FynixHost, resource_changed};
 
 use super::PANEL_PADDING;
 use crate::{ProjectBookmarks, ProjectPath};
@@ -47,13 +47,13 @@ pub(super) struct AssetFoldState(BTreeSet<PathBuf>);
 
 pub(super) struct AssetsPanel;
 
-impl Composer<BevyHost> for AssetsPanel {
+impl Composer<FynixHost> for AssetsPanel {
     type Element = Panel;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Panel> {
+    ) -> ElementHandle<FynixHost, Panel> {
         ui.elem(elem!(Panel))
             .with(|ui| {
                 ui.compose(Listing);
@@ -67,13 +67,13 @@ impl Composer<BevyHost> for AssetsPanel {
 /// put however far the list is scrolled.
 struct AddButton;
 
-impl Composer<BevyHost> for AddButton {
+impl Composer<FynixHost> for AddButton {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(
             Frame,
             position = PositionType::Absolute,
@@ -121,13 +121,13 @@ fn add_bookmark(world: &mut World) {
 
 struct Listing;
 
-impl Composer<BevyHost> for Listing {
+impl Composer<FynixHost> for Listing {
     type Element = ScrollArea;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, ScrollArea> {
+    ) -> ElementHandle<FynixHost, ScrollArea> {
         ui.elem(elem!(
             ScrollArea,
             width = percent(100),
@@ -148,7 +148,7 @@ impl Composer<BevyHost> for Listing {
 /// Fires on either resource, since [`build_bookmarks`] draws from
 /// both.
 fn bookmarks_or_project_changed()
--> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+-> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -190,13 +190,13 @@ struct BookmarkRow {
     path: PathBuf,
 }
 
-impl Composer<BevyHost> for BookmarkRow {
+impl Composer<FynixHost> for BookmarkRow {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let Self { index, path } = self;
         let name = display_name(&path);
         let enabled = has_entries(&path);
@@ -227,7 +227,7 @@ impl Composer<BevyHost> for BookmarkRow {
             ),
             folds_on: FoldsOn::Header,
             enabled,
-            on_header: move |mut header: ElementMut<BevyHost, ButtonElem>| {
+            on_header: move |mut header: ElementMut<FynixHost, ButtonElem>| {
                 // Nothing to drop for the project's own folder.
                 let Some(index) = index else {
                     return;
@@ -310,13 +310,13 @@ struct FolderRow {
     path: PathBuf,
 }
 
-impl Composer<BevyHost> for FolderRow {
+impl Composer<FynixHost> for FolderRow {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let path = self.path;
         let name = display_name(&path);
         let enabled = has_entries(&path);
@@ -346,7 +346,7 @@ impl Composer<BevyHost> for FolderRow {
             ),
             folds_on: FoldsOn::Header,
             enabled,
-            on_header: |_: ElementMut<BevyHost, ButtonElem>| {},
+            on_header: |_: ElementMut<FynixHost, ButtonElem>| {},
             body: move |ui: &mut BevyUi| {
                 build_children(ui, &path);
             },

--- a/editor/moxie/src/ui/hierarchy.rs
+++ b/editor/moxie/src/ui/hierarchy.rs
@@ -27,7 +27,7 @@ use moxie_ui::elements::{
 };
 use moxie_ui::fold::{Foldable, FoldsOn};
 use moxie_ui::reactive::{
-    BevyHost, BevyUi, component_changed_on, value_changed,
+    BevyUi, FynixHost, component_changed_on, value_changed,
 };
 
 use super::PANEL_PADDING;
@@ -52,13 +52,13 @@ const BUTTON_CLEARANCE: f32 = 34.0;
 /// as a whole.
 pub(super) struct HierarchyPanel;
 
-impl Composer<BevyHost> for HierarchyPanel {
+impl Composer<FynixHost> for HierarchyPanel {
     type Element = Panel;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Panel> {
+    ) -> ElementHandle<FynixHost, Panel> {
         ui.elem(elem!(Panel))
             .with(|ui| {
                 ui.compose(Roots);
@@ -74,13 +74,13 @@ impl Composer<BevyHost> for HierarchyPanel {
 /// stays put however far the list is scrolled.
 struct AddButton;
 
-impl Composer<BevyHost> for AddButton {
+impl Composer<FynixHost> for AddButton {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(
             Frame,
             position = PositionType::Absolute,
@@ -109,13 +109,13 @@ impl Composer<BevyHost> for AddButton {
 /// The subjects themselves, scrolling under the button.
 struct Roots;
 
-impl Composer<BevyHost> for Roots {
+impl Composer<FynixHost> for Roots {
     type Element = ScrollArea;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, ScrollArea> {
+    ) -> ElementHandle<FynixHost, ScrollArea> {
         // Roots only: a branch minds itself. The query is kept
         // because this polls every flush, and the build (which
         // makes its own) runs far less often.
@@ -248,13 +248,13 @@ struct Subtree {
     entity: Entity,
 }
 
-impl Composer<BevyHost> for Subtree {
+impl Composer<FynixHost> for Subtree {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let entity = self.entity;
         let name = name_of(ui.world, entity);
         let text = ui.theme.text_primary;
@@ -282,7 +282,7 @@ impl Composer<BevyHost> for Subtree {
             on_header: move |mut header: ElementMut<
                 '_,
                 '_,
-                BevyHost,
+                FynixHost,
                 ButtonElem,
             >| {
                 drag::rows(&mut header, entity)
@@ -371,7 +371,7 @@ fn highlight(world: &World, entity: Entity, accent: Color) -> Color {
 /// Fires when either half of what [`highlight`] reads moves.
 fn highlight_changed(
     entity: Entity,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool {
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool {
     value_changed(move |world, _| {
         (
             world.resource::<SelectedEntity>().0 == Some(entity),
@@ -386,7 +386,7 @@ fn highlight_changed(
 fn drop_changed(
     entity: Entity,
     at: drag::At,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool {
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool {
     value_changed(move |world, _| {
         world.resource::<drag::Dragging>().shows(entity, at)
     })

--- a/editor/moxie/src/ui/hierarchy/drag.rs
+++ b/editor/moxie/src/ui/hierarchy/drag.rs
@@ -16,7 +16,7 @@ use bevy_fynix::{BevyFynix, WorldEntityMut};
 use fynix::element::Element;
 use fynix::ui::ElementMut;
 use moxie_ui::elements::ButtonElem;
-use moxie_ui::reactive::BevyHost;
+use moxie_ui::reactive::FynixHost;
 use moxie_ui::theme::EditorTheme;
 
 /// Where the ghost sits relative to the cursor, so the cursor lands
@@ -54,9 +54,9 @@ pub(crate) enum At {
 
 /// Makes `header` a row that can be picked up, and dropped into.
 pub(super) fn rows<'r, 'u, 'a>(
-    header: &'r mut ElementMut<'u, 'a, BevyHost, ButtonElem>,
+    header: &'r mut ElementMut<'u, 'a, FynixHost, ButtonElem>,
     subject: Entity,
-) -> &'r mut ElementMut<'u, 'a, BevyHost, ButtonElem> {
+) -> &'r mut ElementMut<'u, 'a, FynixHost, ButtonElem> {
     drops(header, subject, At::Into);
 
     header
@@ -118,11 +118,11 @@ pub(super) fn rows<'r, 'u, 'a>(
 
 /// Makes `elem` somewhere a row can be dropped, landing it at `at`
 /// relative to `subject`.
-pub(super) fn drops<'r, 'u, 'a, E: Element<BevyHost>>(
-    elem: &'r mut ElementMut<'u, 'a, BevyHost, E>,
+pub(super) fn drops<'r, 'u, 'a, E: Element<FynixHost>>(
+    elem: &'r mut ElementMut<'u, 'a, FynixHost, E>,
     subject: Entity,
     at: At,
-) -> &'r mut ElementMut<'u, 'a, BevyHost, E> {
+) -> &'r mut ElementMut<'u, 'a, FynixHost, E> {
     elem.observe(
         move |over: On<Pointer<DragOver>>,
               mut dragging: ResMut<Dragging>| {

--- a/editor/moxie/src/ui/inspector.rs
+++ b/editor/moxie/src/ui/inspector.rs
@@ -6,7 +6,7 @@ use fynix::composer::Composer;
 use fynix::elem;
 use fynix::ui::ElementHandle;
 use moxie_ui::elements::{EntityInspector, Label, ScrollArea};
-use moxie_ui::reactive::{BevyHost, BevyUi, resource_changed};
+use moxie_ui::reactive::{BevyUi, FynixHost, resource_changed};
 
 use super::PANEL_PADDING;
 use crate::SelectedEntity;
@@ -14,13 +14,13 @@ use crate::SelectedEntity;
 /// The inspector panel, as kernel nodes.
 pub(super) struct InspectorPanel;
 
-impl Composer<BevyHost> for InspectorPanel {
+impl Composer<FynixHost> for InspectorPanel {
     type Element = ScrollArea;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, ScrollArea> {
+    ) -> ElementHandle<FynixHost, ScrollArea> {
         ui.elem(elem!(
             ScrollArea,
             width = percent(100),

--- a/editor/moxie/src/ui/settings.rs
+++ b/editor/moxie/src/ui/settings.rs
@@ -11,7 +11,7 @@ use fynix::{elem, val};
 use moxie_ui::elements::{
     Button, Frame, Label, Panel, ResourceInspector,
 };
-use moxie_ui::reactive::{BevyHost, BevyUi};
+use moxie_ui::reactive::{BevyUi, FynixHost};
 
 use super::PANEL_PADDING;
 use crate::EditorSettings;
@@ -19,13 +19,13 @@ use crate::EditorSettings;
 /// The settings panel, as kernel nodes.
 pub(super) struct SettingsPanel;
 
-impl Composer<BevyHost> for SettingsPanel {
+impl Composer<FynixHost> for SettingsPanel {
     type Element = Panel;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Panel> {
+    ) -> ElementHandle<FynixHost, Panel> {
         ui.elem(elem!(
             Panel,
             direction = FlexDirection::Column,
@@ -45,13 +45,13 @@ impl Composer<BevyHost> for SettingsPanel {
 /// The one action the panel has of its own.
 struct SaveRow;
 
-impl Composer<BevyHost> for SaveRow {
+impl Composer<FynixHost> for SaveRow {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(Frame, direction = FlexDirection::Row))
             .with(|ui| {
                 ui.elem(elem!(

--- a/editor/moxie/src/ui/timeline.rs
+++ b/editor/moxie/src/ui/timeline.rs
@@ -34,7 +34,7 @@ use moxie_ui::elements::{
 use moxie_ui::fold::{CHEVRON_OPEN, CHEVRON_SHUT};
 use moxie_ui::motion::MotionExt;
 use moxie_ui::reactive::{
-    BevyHost, BevyUi, resource_changed, value_changed,
+    BevyUi, FynixHost, resource_changed, value_changed,
 };
 
 /// Folded blocks, by path.
@@ -66,13 +66,13 @@ struct TrackViewport;
 /// `bsn!` tree.
 pub(super) struct TimelinePanel;
 
-impl Composer<BevyHost> for TimelinePanel {
+impl Composer<FynixHost> for TimelinePanel {
     type Element = Panel;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Panel> {
+    ) -> ElementHandle<FynixHost, Panel> {
         ui.elem(elem!(Panel))
             .with(|ui| {
                 ui.elem(elem!(
@@ -93,13 +93,13 @@ impl Composer<BevyHost> for TimelinePanel {
 /// Play/pause + time readout.
 struct ControlBar;
 
-impl Composer<BevyHost> for ControlBar {
+impl Composer<FynixHost> for ControlBar {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(
             Frame,
             width = percent(100),
@@ -157,13 +157,13 @@ impl Composer<BevyHost> for ControlBar {
 /// The time axis ruler above the tracks.
 struct TimeAxis;
 
-impl Composer<BevyHost> for TimeAxis {
+impl Composer<FynixHost> for TimeAxis {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(
             Frame,
             width = percent(100),
@@ -195,15 +195,15 @@ fn build_ticks(ui: &mut BevyUi) {
         let major = tick.label.is_some();
         ui.elem(elem!(
             TimeTick,
-            x = tick.x,
-            height = if major { MAJOR_TICK } else { MINOR_TICK },
+            x = px(tick.x),
+            height = px(if major { MAJOR_TICK } else { MINOR_TICK }),
             color = color.with_alpha(if major { 0.6 } else { 0.3 })
         ));
 
         if let Some(text) = tick.label {
             ui.elem(elem!(
                 TimeLabel,
-                x = tick.x,
+                x = px(tick.x),
                 label = val!(
                     Label,
                     text = text,
@@ -221,13 +221,13 @@ fn build_ticks(ui: &mut BevyUi) {
 /// [`ScrollArea`] neither scrolls nor clips it.
 struct TrackArea;
 
-impl Composer<BevyHost> for TrackArea {
+impl Composer<FynixHost> for TrackArea {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(
             Frame,
             width = percent(100),
@@ -244,7 +244,7 @@ impl Composer<BevyHost> for TrackArea {
                 |line| line.left(),
                 resource_changed::<MotionGfxManager>(),
                 |WorldNodeRef { world, node }| {
-                    crate::px_for(current_time(world, node))
+                    px(crate::px_for(current_time(world, node)))
                 },
             );
         })
@@ -331,10 +331,10 @@ fn build_block_boxes(ui: &mut BevyUi) {
                         size = 10.0f32,
                         color = Some(theme.text_primary.with_alpha(0.8))
                     ),
-                    top = placed.y,
-                    left = placed.x,
-                    width = placed.w,
-                    height = placed.h,
+                    top = px(placed.y),
+                    left = px(placed.x),
+                    width = px(placed.w),
+                    height = px(placed.h),
                     background = theme.text_primary.with_alpha(0.04),
                     border = if is_selected {
                         theme.accent
@@ -426,10 +426,10 @@ fn build_block_boxes(ui: &mut BevyUi) {
                             theme.palette.blue.with_alpha(0.9)
                         })
                     ),
-                    top = placed.y,
-                    left = placed.x,
-                    width = placed.w,
-                    height = placed.h,
+                    top = px(placed.y),
+                    left = px(placed.x),
+                    width = px(placed.w),
+                    height = px(placed.h),
                     fill = fill,
                     border = if is_selected {
                         theme.accent

--- a/editor/moxie/src/ui/top_bar.rs
+++ b/editor/moxie/src/ui/top_bar.rs
@@ -14,20 +14,20 @@ use moxie_ui::elements::{
     DropdownMenu, Frame, Label, MenuButton,
 };
 use moxie_ui::motion::MotionExt;
-use moxie_ui::reactive::{BevyHost, BevyUi};
+use moxie_ui::reactive::{BevyUi, FynixHost};
 use moxie_ui::theme::EditorTheme;
 
 use crate::project;
 
 pub(super) struct TopBar;
 
-impl Composer<BevyHost> for TopBar {
+impl Composer<FynixHost> for TopBar {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         ui.elem(elem!(
             Frame,
             width = percent(100),
@@ -53,13 +53,13 @@ struct Menu {
     entries: Vec<(&'static str, fn(&mut World))>,
 }
 
-impl Composer<BevyHost> for Menu {
+impl Composer<FynixHost> for Menu {
     type Element = DropdownMenu;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, DropdownMenu> {
+    ) -> ElementHandle<FynixHost, DropdownMenu> {
         let Self { name, entries } = self;
         let theme = ui.theme;
         // Sized to the longest entry, so the list clears its own text

--- a/editor/moxie_ui/src/asset.rs
+++ b/editor/moxie_ui/src/asset.rs
@@ -18,7 +18,7 @@ use bevy_fynix::{BevyFynix, WorldEntityMut};
 use fynix::element::Element;
 use fynix::ui::ElementMut;
 
-use crate::reactive::BevyHost;
+use crate::reactive::FynixHost;
 use crate::theme::EditorTheme;
 
 /// Where the ghost sits relative to the cursor, so the cursor lands
@@ -36,12 +36,12 @@ pub struct AssetDragging {
 
 /// Makes `elem` a file that can be picked up and dragged onto an
 /// asset field, named `label` while it follows the cursor.
-pub fn draggable<'r, 'u, 'a, E: Element<BevyHost>>(
-    elem: &'r mut ElementMut<'u, 'a, BevyHost, E>,
+pub fn draggable<'r, 'u, 'a, E: Element<FynixHost>>(
+    elem: &'r mut ElementMut<'u, 'a, FynixHost, E>,
     path: PathBuf,
     kind: TypeId,
     label: String,
-) -> &'r mut ElementMut<'u, 'a, BevyHost, E> {
+) -> &'r mut ElementMut<'u, 'a, FynixHost, E> {
     elem.observe(
         move |start: On<Pointer<DragStart>>,
               kernel: Res<BevyFynix<EditorTheme>>,

--- a/editor/moxie_ui/src/elements.rs
+++ b/editor/moxie_ui/src/elements.rs
@@ -1,9 +1,10 @@
 //! What the editor is built out of.
 //!
 //! A widget is a struct rather than a `bsn!` scene: its fields are
-//! the data, [`ElementVisual`](fynix::element::ElementVisual)
-//! says what they mean to bevy, and a binding names one of them, so
-//! a value can change without the node being rebuilt.
+//! the data, its `#[elem(patch = ...)]` writers and
+//! `#[element(build = ...)]` hook say what they mean to bevy, and a
+//! binding names one of them, so a value can change without the node
+//! being rebuilt.
 
 pub mod dock;
 
@@ -17,6 +18,7 @@ mod inspector;
 mod label;
 mod overlay;
 mod panel;
+mod patch;
 mod playhead;
 mod scroll_area;
 mod segmented_control;

--- a/editor/moxie_ui/src/elements/button.rs
+++ b/editor/moxie_ui/src/elements/button.rs
@@ -1,21 +1,21 @@
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::feathers::cursor::EntityCursor;
 use bevy::prelude::*;
 use bevy::ui_widgets::Button as ButtonBehavior;
 use bevy::window::SystemCursorIcon;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
+use fynix::element::element;
 use fynix::style::Style;
-use fynix::ui::{Build, Patch};
+use fynix::ui::Patch;
 
+use super::patch::{self, node};
 use super::{Icon, IconCursor, Label, LabelCursor};
 use crate::motion::LitFrom as _;
 use crate::theme::EditorTheme;
 
 /// What lights up under the cursor, and to what colour. A style has
-/// no node to wire this on, so it leaves the choice here for
-/// [`build_fields`](ElementVisual::build_fields) to read once the
-/// node exists.
+/// no node to wire this on, so it leaves the choice here for the
+/// `#[element(build = ...)]` hook to read once the node exists.
 #[derive(Clone, Copy, PartialEq, Default)]
 pub enum Hover {
     /// Nothing lights up.
@@ -31,7 +31,7 @@ pub enum Hover {
 /// A hit area holding an icon, a label, both, or whatever is built
 /// under it, with no look of its own. [`Button`] and [`GhostButton`]
 /// are two the editor gives it.
-#[element]
+#[element(build = Self::build)]
 pub struct ButtonElem {
     /// A node of its own, so its image and colour can be bound
     /// without touching the button.
@@ -43,62 +43,47 @@ pub struct ButtonElem {
     pub label: Option<Label>,
     /// Between the icon and the label, when both are there.
     #[default(px(6))]
+    #[elem(patch = patch::column_gap)]
     pub column_gap: Val,
     /// What the background shows. Nothing by default, which is a
     /// [`GhostButton`]; [`Button`] rests at the theme's own fill, and
     /// interaction lights either of them up.
     #[default(::NONE)]
+    #[elem(patch = patch::background)]
     pub fill: Color,
+    #[elem(patch = patch::width)]
     pub width: Val,
+    #[elem(patch = patch::height)]
     pub height: Val,
     /// Share of a flex row's remaining space this button claims, for
     /// one that should fill a row rather than size to its own content.
+    #[elem(patch = patch::flex_grow)]
     pub flex_grow: f32,
     #[default(px(18))]
+    #[elem(patch = patch::min_width)]
     pub min_width: Val,
     #[default(px(18))]
+    #[elem(patch = patch::min_height)]
     pub min_height: Val,
     /// Centred, for a button that is only as big as what it holds.
     #[default(::Center)]
+    #[elem(patch = patch::justify)]
     pub justify: JustifyContent,
+    #[elem(patch = patch::padding)]
     pub padding: UiRect,
     #[default(::ZERO)]
+    #[elem(patch = patch::radius)]
     pub radius: Val,
     /// Overrides `radius` with independent corners, for a button that
     /// sits at one end of a row of others (a
     /// [`SegmentedControl`](super::SegmentedControl)'s outer
     /// segments). `None` rounds all four corners by `radius`.
+    #[elem(patch = corners)]
     pub corners: Option<BorderRadius>,
     /// Set by whichever [`Style`] built this - see [`Hover`]. Never
-    /// patched: read once, in `build_fields`.
+    /// patched: read once, when the lanes are wired.
     #[elem(ignore)]
     hover: Hover,
-}
-
-impl ButtonElem {
-    fn node(&self) -> Node {
-        Node {
-            min_width: self.min_width,
-            min_height: self.min_height,
-            width: self.width,
-            height: self.height,
-            flex_grow: self.flex_grow,
-            justify_content: self.justify,
-            align_items: AlignItems::Center,
-            column_gap: self.column_gap,
-            padding: self.padding,
-            border_radius: self
-                .corners
-                .unwrap_or(BorderRadius::all(self.radius)),
-            ..default()
-        }
-    }
-
-    /// `fill` alone, so a lane aiming it under the cursor takes
-    /// effect whichever look the button wears.
-    fn background(&self) -> BackgroundColor {
-        BackgroundColor(self.fill)
-    }
 }
 
 /// The editor's own button: a filled, rounded pill sized for a
@@ -106,7 +91,7 @@ impl ButtonElem {
 pub struct Button;
 
 impl Style for Button {
-    type Host = BevyHost;
+    type Host = FynixHost;
     type Element = ButtonElem;
 
     fn apply(self, button: &mut ButtonElem, theme: &EditorTheme) {
@@ -128,7 +113,7 @@ pub struct TintButton {
 }
 
 impl Style for TintButton {
-    type Host = BevyHost;
+    type Host = FynixHost;
     type Element = ButtonElem;
 
     fn apply(self, button: &mut ButtonElem, theme: &EditorTheme) {
@@ -142,7 +127,7 @@ impl Style for TintButton {
 pub struct MenuButton;
 
 impl Style for MenuButton {
-    type Host = BevyHost;
+    type Host = FynixHost;
     type Element = ButtonElem;
 
     fn apply(self, button: &mut ButtonElem, theme: &EditorTheme) {
@@ -163,7 +148,7 @@ pub struct SegmentButton {
 }
 
 impl Style for SegmentButton {
-    type Host = BevyHost;
+    type Host = FynixHost;
     type Element = ButtonElem;
 
     fn apply(self, button: &mut ButtonElem, theme: &EditorTheme) {
@@ -188,7 +173,7 @@ impl Style for SegmentButton {
 pub struct GhostButton;
 
 impl Style for GhostButton {
-    type Host = BevyHost;
+    type Host = FynixHost;
     type Element = ButtonElem;
 
     fn apply(self, button: &mut ButtonElem, theme: &EditorTheme) {
@@ -199,16 +184,18 @@ impl Style for GhostButton {
     }
 }
 
-impl ElementVisual<BevyHost> for ButtonElem {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl ButtonElem {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            self.background(),
+            Node {
+                align_items: AlignItems::Center,
+                ..default()
+            },
             ButtonBehavior,
             EntityCursor::System(SystemCursorIcon::Pointer),
         ));
 
-        // Wired against a base already in hand as `&self`: the node
+        // Wired against a base already in hand as `self`: the node
         // has no entry in the kernel's table yet for `.lit()` to read
         // one from. Both stops light to the same colour: `Hover`
         // carries one shade, not separate hover/press ones.
@@ -253,30 +240,15 @@ impl ElementVisual<BevyHost> for ButtonElem {
             }
         }
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: ButtonElemField,
-    ) {
-        match field {
-            ButtonElemField::Fill => {
-                patch.insert(self.background());
-            }
-            // Every other field is one of `Node`'s, and writing it
-            // whole is one insert either way.
-            ButtonElemField::MinWidth
-            | ButtonElemField::MinHeight
-            | ButtonElemField::Width
-            | ButtonElemField::Height
-            | ButtonElemField::FlexGrow
-            | ButtonElemField::Justify
-            | ButtonElemField::ColumnGap
-            | ButtonElemField::Padding
-            | ButtonElemField::Radius
-            | ButtonElemField::Corners => {
-                patch.insert(self.node());
-            }
-        }
+/// Overrides `radius` when set; leaves it be when `None`, so the two
+/// can be patched independently.
+fn corners(
+    patch: &mut Patch<FynixHost>,
+    corners: &Option<BorderRadius>,
+) {
+    if let Some(radius) = *corners {
+        node(patch, move |n| n.border_radius = radius);
     }
 }

--- a/editor/moxie_ui/src/elements/button.rs
+++ b/editor/moxie_ui/src/elements/button.rs
@@ -86,6 +86,64 @@ pub struct ButtonElem {
     hover: Hover,
 }
 
+impl ButtonElem {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        build.insert((
+            Node {
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            ButtonBehavior,
+            EntityCursor::System(SystemCursorIcon::Pointer),
+        ));
+
+        // Wired against a base already in hand as `self`: the node
+        // has no entry in the kernel's table yet for `.lit()` to read
+        // one from. Both stops light to the same colour: `Hover`
+        // carries one shade, not separate hover/press ones.
+        let (fill, icon_label) = match self.hover {
+            Hover::None => (None, None),
+            Hover::Fill(color) => (Some(color), None),
+            Hover::IconLabel(color) => (None, Some(color)),
+        };
+
+        if let Some(color) = fill {
+            build.lit_from(
+                |button| button.fill(),
+                self.fill,
+                color,
+                color,
+            );
+        }
+
+        if let Some(tint) = icon_label {
+            // Read straight from `self`: an absent icon/label is
+            // skipped, same as if it were never lit at all.
+            if let Some(icon) = &self.icon {
+                build.lit_from(
+                    |button| button.icon().color(),
+                    icon.color,
+                    tint,
+                    tint,
+                );
+            }
+            // `label().color()` hops through the `Option`
+            // transparently, so its base is `Color`. A label with no
+            // colour of its own has nowhere for that hop to land.
+            if let Some(color) =
+                self.label.as_ref().and_then(|label| label.color)
+            {
+                build.lit_from(
+                    |button| button.label().color(),
+                    color,
+                    tint,
+                    tint,
+                );
+            }
+        }
+    }
+}
+
 /// The editor's own button: a filled, rounded pill sized for a
 /// toolbar, that lights up under the cursor.
 pub struct Button;
@@ -181,64 +239,6 @@ impl Style for GhostButton {
         button.hover = Hover::Fill(theme.hover_overlay);
         button.padding = UiRect::axes(px(8), px(4));
         button.radius = px(4);
-    }
-}
-
-impl ButtonElem {
-    fn build(&self, build: &mut FynixBuild<'_, Self>) {
-        build.insert((
-            Node {
-                align_items: AlignItems::Center,
-                ..default()
-            },
-            ButtonBehavior,
-            EntityCursor::System(SystemCursorIcon::Pointer),
-        ));
-
-        // Wired against a base already in hand as `self`: the node
-        // has no entry in the kernel's table yet for `.lit()` to read
-        // one from. Both stops light to the same colour: `Hover`
-        // carries one shade, not separate hover/press ones.
-        let (fill, icon_label) = match self.hover {
-            Hover::None => (None, None),
-            Hover::Fill(color) => (Some(color), None),
-            Hover::IconLabel(color) => (None, Some(color)),
-        };
-
-        if let Some(color) = fill {
-            build.lit_from(
-                |button| button.fill(),
-                self.fill,
-                color,
-                color,
-            );
-        }
-
-        if let Some(tint) = icon_label {
-            // Read straight from `self`: an absent icon/label is
-            // skipped, same as if it were never lit at all.
-            if let Some(icon) = &self.icon {
-                build.lit_from(
-                    |button| button.icon().color(),
-                    icon.color,
-                    tint,
-                    tint,
-                );
-            }
-            // `label().color()` hops through the `Option`
-            // transparently, so its base is `Color`. A label with no
-            // colour of its own has nowhere for that hop to land.
-            if let Some(color) =
-                self.label.as_ref().and_then(|label| label.color)
-            {
-                build.lit_from(
-                    |button| button.label().color(),
-                    color,
-                    tint,
-                    tint,
-                );
-            }
-        }
     }
 }
 

--- a/editor/moxie_ui/src/elements/divider.rs
+++ b/editor/moxie_ui/src/elements/divider.rs
@@ -1,81 +1,69 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixHost;
 use bevy::feathers::cursor::EntityCursor;
 use bevy::prelude::*;
 use bevy::ui_widgets::ControlOrientation;
 use bevy::window::SystemCursorIcon;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+use fynix::ui::Patch;
+
+use super::patch::{self, node};
 
 const DIVIDER_WIDTH: f32 = 6.0;
 
 /// The draggable line between two panes.
 #[element]
 pub struct Divider {
+    #[elem(patch = thickness)]
     #[default(px(DIVIDER_WIDTH))]
     pub thickness: Val,
+    #[elem(patch = orientation)]
     #[default(::Horizontal)]
     pub orientation: ControlOrientation,
+    #[elem(patch = patch::background)]
     #[default(Color::srgba(1.0, 1.0, 1.0, 0.08))]
     pub color: Color,
 }
 
-impl Divider {
-    /// The two that the orientation decides between: which way the
-    /// line runs, and what the cursor says it will do.
-    fn shape(&self) -> (Node, SystemCursorIcon) {
-        let (width, height, cursor) = match self.orientation {
-            ControlOrientation::Horizontal => (
-                percent(100),
-                self.thickness,
-                SystemCursorIcon::NsResize,
-            ),
-            ControlOrientation::Vertical => (
-                self.thickness,
-                percent(100),
-                SystemCursorIcon::EwResize,
-            ),
-        };
-
-        (
-            Node {
-                width,
-                height,
-                flex_shrink: 0.0,
-                ..default()
-            },
-            cursor,
-        )
-    }
+/// The axis the line runs along, read back from whichever dimension
+/// is the full-length one.
+fn horizontal(node: &Node) -> bool {
+    node.width == percent(100)
 }
 
-impl ElementVisual<BevyHost> for Divider {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        let (layout, cursor) = self.shape();
+fn thickness(patch: &mut Patch<FynixHost>, thickness: &Val) {
+    node(patch, |n| {
+        if horizontal(n) {
+            n.height = *thickness;
+        } else {
+            n.width = *thickness;
+        }
+    });
+}
 
-        build.insert((
-            layout,
-            BackgroundColor(self.color),
-            EntityCursor::System(cursor),
-        ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: DividerField,
-    ) {
-        match field {
-            // Either one changes both: the thickness lands on
-            // whichever axis the orientation put it.
-            DividerField::Thickness | DividerField::Orientation => {
-                let (layout, cursor) = self.shape();
-
-                patch.insert((layout, EntityCursor::System(cursor)));
+fn orientation(
+    patch: &mut Patch<FynixHost>,
+    orientation: &ControlOrientation,
+) {
+    let cursor = match orientation {
+        ControlOrientation::Horizontal => SystemCursorIcon::NsResize,
+        ControlOrientation::Vertical => SystemCursorIcon::EwResize,
+    };
+    let orientation = *orientation;
+    node(patch, move |n| {
+        let thickness =
+            if horizontal(n) { n.height } else { n.width };
+        match orientation {
+            ControlOrientation::Horizontal => {
+                n.width = percent(100);
+                n.height = thickness;
             }
-            DividerField::Color => {
-                patch.insert(BackgroundColor(self.color));
+            ControlOrientation::Vertical => {
+                n.width = thickness;
+                n.height = percent(100);
             }
         }
-    }
+        n.flex_shrink = 0.0;
+    });
+    patch.insert(EntityCursor::System(cursor));
 }

--- a/editor/moxie_ui/src/elements/dock.rs
+++ b/editor/moxie_ui/src/elements/dock.rs
@@ -6,11 +6,13 @@
 //!
 //! [`DockTree`]: crate::widgets::dock::DockTree
 
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+use fynix::ui::Patch;
+
+use super::patch::{node, with};
 
 use super::Frame;
 use crate::widgets::dock::{
@@ -24,7 +26,7 @@ use crate::widgets::dock::{
 /// `min_width`/`min_height` at `0`, not `Node`'s own default `Auto`,
 /// which floors a node at its content's size regardless of the `100%`
 /// above.
-fn filled(direction: FlexDirection) -> Node {
+pub(super) fn filled(direction: FlexDirection) -> Node {
     Node {
         width: percent(100),
         height: percent(100),
@@ -36,7 +38,7 @@ fn filled(direction: FlexDirection) -> Node {
     }
 }
 
-fn display(visible: bool) -> Display {
+pub(super) fn display(visible: bool) -> Display {
     if visible {
         Display::Flex
     } else {
@@ -45,11 +47,11 @@ fn display(visible: bool) -> Display {
 }
 
 /// The node the whole tree is rendered underneath.
-#[element]
+#[element(build = Self::build)]
 pub struct DockHost;
 
-impl ElementVisual<BevyHost> for DockHost {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl DockHost {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             DockTreeHost,
             Node {
@@ -62,70 +64,57 @@ impl ElementVisual<BevyHost> for DockHost {
             },
         ));
     }
-
-    fn patch_fields(
-        &self,
-        _patch: &mut Patch<BevyHost>,
-        field: DockHostField,
-    ) {
-        match field {}
-    }
 }
 
-/// A split: two panels and the handle between them.
+/// A split: two panels and the handle between them. Each field
+/// writes its own component whole, so it needs no build hook.
 #[element]
 pub struct SplitGroup {
+    #[elem(patch = patch_group_node)]
     #[default(NodeId(0))]
     pub node: NodeId,
+    #[elem(patch = patch_group_min_ratio)]
     #[default(0.05)]
     pub min_ratio: f32,
+    #[elem(patch = patch_group_axis)]
     #[default(::Row)]
     pub axis: FlexDirection,
 }
 
-impl ElementVisual<BevyHost> for SplitGroup {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        build.insert((
-            NodeBinding(self.node),
-            PanelGroup {
-                min_ratio: self.min_ratio,
-            },
-            filled(self.axis),
-        ));
-    }
+fn patch_group_node(patch: &mut Patch<FynixHost>, node: &NodeId) {
+    patch.insert(NodeBinding(*node));
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: SplitGroupField,
-    ) {
-        match field {
-            SplitGroupField::Node => {
-                patch.insert(NodeBinding(self.node));
-            }
-            SplitGroupField::MinRatio => {
-                patch.insert(PanelGroup {
-                    min_ratio: self.min_ratio,
-                });
-            }
-            SplitGroupField::Axis => {
-                patch.insert(filled(self.axis));
-            }
-        }
-    }
+fn patch_group_min_ratio(
+    patch: &mut Patch<FynixHost>,
+    min_ratio: &f32,
+) {
+    patch.insert(PanelGroup {
+        min_ratio: *min_ratio,
+    });
+}
+
+fn patch_group_axis(
+    patch: &mut Patch<FynixHost>,
+    axis: &FlexDirection,
+) {
+    patch.insert(filled(*axis));
 }
 
 /// What a split is dragged by: a full-sized hit area holding a
 /// slim, always-visible [`line`](Self::line) and a wider
 /// [`bar`](Self::bar) that only shows on hover.
-#[element]
+#[element(build = Self::build)]
 pub struct SplitHandle {
+    #[elem(patch = patch_handle_node)]
     #[default(NodeId(0))]
     pub node: NodeId,
+    #[elem(patch = patch_handle_axis)]
     #[default(::Row)]
     pub axis: FlexDirection,
     /// Hidden when either side of the split has collapsed: there is
     /// nothing left to drag between.
+    #[elem(patch = patch_handle_visible)]
     #[default(true)]
     pub visible: bool,
     /// Marks the seam at rest. Never interactive, and never lit -
@@ -137,33 +126,6 @@ pub struct SplitHandle {
     /// colors the handle.
     #[elem(child)]
     pub bar: Frame,
-}
-
-impl SplitHandle {
-    /// Full-sized hit area, pulled back onto the seam by a matching
-    /// negative margin so the panels read as touching. Centers
-    /// [`bar`](Self::bar), which carries its own thinner size.
-    fn node(&self) -> Node {
-        let pull = px(-HANDLE_SIZE / 2.0);
-        let margin = match self.axis {
-            FlexDirection::Row | FlexDirection::RowReverse => {
-                UiRect::horizontal(pull)
-            }
-            FlexDirection::Column | FlexDirection::ColumnReverse => {
-                UiRect::vertical(pull)
-            }
-        };
-
-        Node {
-            min_width: px(HANDLE_SIZE),
-            min_height: px(HANDLE_SIZE),
-            margin,
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
-            display: display(self.visible),
-            ..default()
-        }
-    }
 }
 
 /// The bar's own size: thin on the split's axis, full-length across
@@ -216,99 +178,112 @@ pub fn handle_line(axis: FlexDirection, color: Color) -> Frame {
     }
 }
 
-impl ElementVisual<BevyHost> for SplitHandle {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl SplitHandle {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             PanelHandle,
             NodeBinding(self.node),
             self.node(),
-            // Overlaps both panels by design; without this the
-            // second one, painted after it, would win the pointer.
+            // Overlaps both panels by design; without self the second one,
+            // painted after it, would win the pointer.
             ZIndex(1),
         ));
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: SplitHandleField,
-    ) {
-        match field {
-            SplitHandleField::Node => {
-                patch.insert(NodeBinding(self.node));
-            }
-            SplitHandleField::Axis | SplitHandleField::Visible => {
-                patch.insert(self.node());
-            }
+/// The negative pull that lands the hit area back on the seam, on the
+/// axis the split runs along.
+pub(super) fn handle_margin(axis: FlexDirection) -> UiRect {
+    let pull = px(-HANDLE_SIZE / 2.0);
+    match axis {
+        FlexDirection::Row | FlexDirection::RowReverse => {
+            UiRect::horizontal(pull)
+        }
+        FlexDirection::Column | FlexDirection::ColumnReverse => {
+            UiRect::vertical(pull)
         }
     }
+}
+
+fn patch_handle_node(patch: &mut Patch<FynixHost>, node: &NodeId) {
+    patch.insert(NodeBinding(*node));
+}
+
+fn patch_handle_axis(
+    patch: &mut Patch<FynixHost>,
+    axis: &FlexDirection,
+) {
+    let margin = handle_margin(*axis);
+    node(patch, move |n| n.margin = margin);
+}
+
+fn patch_handle_visible(
+    patch: &mut Patch<FynixHost>,
+    visible: &bool,
+) {
+    let display = display(*visible);
+    node(patch, move |n| n.display = display);
 }
 
 /// One side of a split. The ratio is bound rather than built:
 /// dragging the handle rewrites it every frame, and must not rebuild
 /// what the panel holds.
-#[element]
+#[element(build = Self::build)]
 pub struct SplitPanel {
+    #[elem(patch = patch_panel_ratio)]
     #[default(1.0)]
     pub ratio: f32,
     /// A collapsed panel takes no space, so its sibling reclaims it.
+    #[elem(patch = patch_panel_visible)]
     #[default(true)]
     pub visible: bool,
 }
 
 impl SplitPanel {
-    fn node(&self) -> Node {
-        let size = if self.visible { percent(100) } else { px(0) };
-
-        Node {
-            width: size,
-            height: size,
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        build.insert(Node {
             flex_direction: FlexDirection::Column,
             overflow: Overflow::clip(),
-            display: display(self.visible),
             ..default()
-        }
+        });
     }
 }
 
-impl ElementVisual<BevyHost> for SplitPanel {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        build.insert((Panel { ratio: self.ratio }, self.node()));
-    }
+fn patch_panel_ratio(patch: &mut Patch<FynixHost>, ratio: &f32) {
+    patch.insert(Panel { ratio: *ratio });
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: SplitPanelField,
-    ) {
-        match field {
-            SplitPanelField::Ratio => {
-                patch.insert(Panel { ratio: self.ratio });
-            }
-            SplitPanelField::Visible => {
-                patch.insert(self.node());
-            }
-        }
-    }
+fn patch_panel_visible(patch: &mut Patch<FynixHost>, visible: &bool) {
+    let size = if *visible { percent(100) } else { px(0) };
+    let display = display(*visible);
+    node(patch, move |n| {
+        n.width = size;
+        n.height = size;
+        n.display = display;
+    });
 }
 
 /// A leaf of the tree: a tab bar, and the content of every tab.
-#[element]
+#[element(build = Self::build)]
 pub struct Area {
+    #[elem(patch = patch_area_node)]
     #[default(NodeId(0))]
     pub node: NodeId,
+    #[elem(patch = patch_area_id)]
     pub id: String,
+    #[elem(patch = patch_area_style)]
     #[default(::TabBar)]
     pub style: DockAreaStyle,
     /// Which tab is showing, which a binding keeps up to date. The
     /// component itself, because a walk hops *into* an `Option`
     /// rather than naming it, and `None` is a value this has to
     /// carry.
+    #[elem(patch = patch_area_active)]
     pub active: ActiveDockWindow,
 }
 
-impl ElementVisual<BevyHost> for Area {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl Area {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             DockArea {
                 id: self.id.clone(),
@@ -319,42 +294,46 @@ impl ElementVisual<BevyHost> for Area {
             filled(FlexDirection::Column),
         ));
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: AreaField,
-    ) {
-        match field {
-            AreaField::Active => {
-                patch.insert(self.active.clone());
-            }
-            AreaField::Node => {
-                patch.insert(NodeBinding(self.node));
-            }
-            AreaField::Id | AreaField::Style => {
-                patch.insert(DockArea {
-                    id: self.id.clone(),
-                    style: self.style.clone(),
-                });
-            }
-        }
-    }
+fn patch_area_active(
+    patch: &mut Patch<FynixHost>,
+    active: &ActiveDockWindow,
+) {
+    patch.insert(active.clone());
+}
+
+fn patch_area_node(patch: &mut Patch<FynixHost>, node: &NodeId) {
+    patch.insert(NodeBinding(*node));
+}
+
+fn patch_area_id(patch: &mut Patch<FynixHost>, id: &String) {
+    with::<DockArea>(patch, |area| area.id.clone_from(id));
+}
+
+fn patch_area_style(
+    patch: &mut Patch<FynixHost>,
+    style: &DockAreaStyle,
+) {
+    with::<DockArea>(patch, |area| area.style = style.clone());
 }
 
 /// One tab's content. Switching tabs flips `display` through a
 /// binding rather than rebuilding: the content owns cameras, scroll
 /// offsets and live edits that have to survive a tab switch.
-#[element]
+#[element(build = Self::build)]
 pub struct TabContent {
+    #[elem(patch = patch_content_window_id)]
     pub window_id: String,
+    #[elem(patch = patch_content_tab)]
     #[default(TabId(0))]
     pub tab: TabId,
+    #[elem(patch = patch_content_showing)]
     pub showing: bool,
 }
 
-impl ElementVisual<BevyHost> for TabContent {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl TabContent {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             DockWindow {
                 descriptor_id: self.window_id.clone(),
@@ -376,35 +355,31 @@ impl ElementVisual<BevyHost> for TabContent {
             },
         ));
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TabContentField,
-    ) {
-        match field {
-            // Only `display`: the content pane's own layout is its
-            // business, and writing the whole `Node` would clobber
-            // whatever it did to itself.
-            TabContentField::Showing => {
-                if let Some(mut layout) =
-                    patch.entity_mut().get_mut::<Node>()
-                {
-                    layout.display = display(self.showing);
-                }
-            }
-            TabContentField::WindowId | TabContentField::Tab => {
-                patch.insert((
-                    DockWindow {
-                        descriptor_id: self.window_id.clone(),
-                        tab_id: self.tab,
-                    },
-                    DockTabContent {
-                        window_id: self.window_id.clone(),
-                        tab_id: self.tab,
-                    },
-                ));
-            }
-        }
-    }
+/// Only `display`: the content pane's own layout is its business, and
+/// writing the whole `Node` would clobber whatever it did to itself.
+fn patch_content_showing(
+    patch: &mut Patch<FynixHost>,
+    showing: &bool,
+) {
+    let display = display(*showing);
+    node(patch, move |n| n.display = display);
+}
+
+fn patch_content_window_id(
+    patch: &mut Patch<FynixHost>,
+    window_id: &String,
+) {
+    with::<DockWindow>(patch, |w| {
+        w.descriptor_id.clone_from(window_id)
+    });
+    with::<DockTabContent>(patch, |c| {
+        c.window_id.clone_from(window_id)
+    });
+}
+
+fn patch_content_tab(patch: &mut Patch<FynixHost>, tab: &TabId) {
+    with::<DockWindow>(patch, |w| w.tab_id = *tab);
+    with::<DockTabContent>(patch, |c| c.tab_id = *tab);
 }

--- a/editor/moxie_ui/src/elements/dock.rs
+++ b/editor/moxie_ui/src/elements/dock.rs
@@ -183,8 +183,8 @@ impl SplitHandle {
         build.insert((
             PanelHandle,
             NodeBinding(self.node),
-            self.node(),
-            // Overlaps both panels by design; without self the second one,
+            filled(self.axis),
+            // Overlaps both panels by design; without it the second one,
             // painted after it, would win the pointer.
             ZIndex(1),
         ));

--- a/editor/moxie_ui/src/elements/dock.rs
+++ b/editor/moxie_ui/src/elements/dock.rs
@@ -183,7 +183,16 @@ impl SplitHandle {
         build.insert((
             PanelHandle,
             NodeBinding(self.node),
-            filled(self.axis),
+            // A small hit area centring `bar`; `axis` pulls it back
+            // onto the seam with a negative margin, `visible` toggles
+            // `display`.
+            Node {
+                min_width: px(HANDLE_SIZE),
+                min_height: px(HANDLE_SIZE),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
             // Overlaps both panels by design; without it the second one,
             // painted after it, would win the pointer.
             ZIndex(1),

--- a/editor/moxie_ui/src/elements/dropdown.rs
+++ b/editor/moxie_ui/src/elements/dropdown.rs
@@ -7,7 +7,7 @@
 //! window edge, dismissal on focus loss, Escape, and arrow-key
 //! navigation.
 
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::feathers::controls::{FeathersMenu, FeathersMenuPopup};
 use bevy::feathers::cursor::EntityCursor;
 use bevy::input_focus::tab_navigation::TabIndex;
@@ -17,10 +17,11 @@ use bevy::ui_widgets::{
     ActivateOnPress, Button as ButtonBehavior, MenuButton, MenuItem,
 };
 use bevy::window::SystemCursorIcon;
-use bevy_fynix::WorldEntityMut;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use bevy_fynix::WorldEntityMut as _;
+use fynix::element::element;
+use fynix::ui::Patch;
 
+use super::patch::{self, node};
 use super::{Icon, Label};
 
 /// What a [`Dropdown`] and its [`DropdownList`] hang from.
@@ -28,29 +29,21 @@ use super::{Icon, Label};
 /// Carries the observer that opens and closes the list, found by
 /// looking through this node's children. Both must be built
 /// underneath it, in either order.
-#[element]
+#[element(build = Self::build)]
 pub struct DropdownMenu;
 
-impl ElementVisual<BevyHost> for DropdownMenu {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl DropdownMenu {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         if let Err(err) =
             build.entity_mut().apply_scene(bsn! { @FeathersMenu })
         {
             error!("failed to build a dropdown: {err}");
         }
     }
-
-    fn patch_fields(
-        &self,
-        _patch: &mut Patch<BevyHost>,
-        field: DropdownMenuField,
-    ) {
-        match field {}
-    }
 }
 
 /// The shut control: what is chosen now, and a chevron.
-#[element]
+#[element(build = Self::build)]
 pub struct Dropdown {
     /// A node of its own, so the choice showing can be bound without
     /// the control being rebuilt.
@@ -59,16 +52,21 @@ pub struct Dropdown {
     #[elem(child)]
     pub chevron: Icon,
     /// Wide enough to stay readable when the choice is a short word.
+    #[elem(patch = patch::min_width)]
     #[default(px(72))]
     pub min_width: Val,
     /// Past this the label is clipped rather than the row growing:
     /// a column of these has to line up.
+    #[elem(patch = patch::max_width)]
     #[default(px(160))]
     pub max_width: Val,
+    #[elem(patch = patch::height)]
     #[default(px(22))]
     pub height: Val,
+    #[elem(patch = patch::background)]
     #[default(Color::srgba(1.0, 1.0, 1.0, 0.06))]
     pub fill: Color,
+    #[elem(patch = patch::radius)]
     #[default(px(4))]
     pub radius: Val,
 }
@@ -96,26 +94,8 @@ impl Dropdown {
         px(longest as f32 * font_size * ADVANCE + FURNITURE)
     }
 
-    fn node(&self) -> Node {
-        Node {
-            min_width: self.min_width,
-            max_width: self.max_width,
-            height: self.height,
-            flex_direction: FlexDirection::Row,
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::SpaceBetween,
-            column_gap: px(6),
-            padding: UiRect::axes(px(8), Val::ZERO),
-            border_radius: BorderRadius::all(self.radius),
-            // What will not fit is the label's problem, not the
-            // row's - see `hold_chevron`.
-            overflow: Overflow::clip(),
-            ..default()
-        }
-    }
-
     /// Keeps the chevron its own size while the label gives way.
-    fn hold_chevron(build: &mut Build<BevyHost, Self>) {
+    fn hold_chevron(build: &mut FynixBuild<'_, Self>) {
         let Some(chevron) = build.child(DropdownCursor::chevron)
         else {
             return;
@@ -128,37 +108,28 @@ impl Dropdown {
     }
 }
 
-impl ElementVisual<BevyHost> for Dropdown {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl Dropdown {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            BackgroundColor(self.fill),
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::SpaceBetween,
+                column_gap: px(6),
+                padding: UiRect::axes(px(8), Val::ZERO),
+                // What will not fit is the label's problem, not the
+                // row's - see `hold_chevron`.
+                overflow: Overflow::clip(),
+                ..default()
+            },
             ButtonBehavior,
-            // Opens the list beside it; the anchor's own observer
-            // does the work.
+            // Opens the list beside it; the anchor's own observer does
+            // the work.
             ActivateOnPress,
             MenuButton,
             EntityCursor::System(SystemCursorIcon::Pointer),
         ));
-        Self::hold_chevron(build);
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: DropdownField,
-    ) {
-        match field {
-            DropdownField::Fill => {
-                patch.insert(BackgroundColor(self.fill));
-            }
-            DropdownField::MinWidth
-            | DropdownField::MaxWidth
-            | DropdownField::Height
-            | DropdownField::Radius => {
-                patch.insert(self.node());
-            }
-        }
+        Dropdown::hold_chevron(build);
     }
 }
 
@@ -167,33 +138,21 @@ impl ElementVisual<BevyHost> for Dropdown {
 /// Placed by the popup scene it is built from, so it flips above the
 /// control rather than off the bottom of the window, and is not
 /// clipped by whatever it was opened inside.
-#[element]
+#[element(build = Self::build)]
 pub struct DropdownList {
     /// Matched to the control's, so the two line up.
+    #[elem(patch = list_width)]
     #[default(px(160))]
     pub width: Val,
     /// What the popup scene rounds its own corners to, so leaving this
     /// alone keeps the look feathers gave it.
+    #[elem(patch = patch::radius)]
     #[default(px(4))]
     pub radius: Val,
 }
 
 impl DropdownList {
-    /// Only the width and the corners. The rest of the node belongs to
-    /// the popup scene, and writing it whole would undo the placement
-    /// that came with it.
-    fn size(&self, entity: &mut impl WorldEntityMut) {
-        if let Some(mut layout) =
-            entity.entity_mut().get_mut::<Node>()
-        {
-            layout.min_width = self.width;
-            layout.border_radius = BorderRadius::all(self.radius);
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for DropdownList {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         if let Err(err) = build
             .entity_mut()
             .apply_scene(bsn! { @FeathersMenuPopup })
@@ -201,75 +160,56 @@ impl ElementVisual<BevyHost> for DropdownList {
             error!("failed to build a dropdown list: {err}");
             return;
         }
-        self.size(build);
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: DropdownListField,
-    ) {
-        match field {
-            DropdownListField::Width | DropdownListField::Radius => {
-                self.size(patch)
-            }
+        // Only the width and the corners: the rest of the node belongs to
+        // the popup scene, and writing it whole would undo the placement.
+        if let Some(mut layout) = build.entity_mut().get_mut::<Node>()
+        {
+            layout.min_width = self.width;
+            layout.border_radius = BorderRadius::all(self.radius);
         }
     }
+}
+
+/// The list is placed by its popup scene, so only its own width lands
+/// on `min_width`.
+fn list_width(patch: &mut Patch<FynixHost>, width: &Val) {
+    node(patch, |n| n.min_width = *width);
 }
 
 /// One row of a [`DropdownList`].
 ///
 /// Picking one closes the list. It also has to be focusable, because
 /// focus is what keeps the list open at all.
-#[element]
+#[element(build = Self::build)]
 pub struct DropdownItem {
     #[elem(child)]
     pub label: Label,
+    #[elem(patch = patch::height)]
     #[default(px(20))]
     pub height: Val,
+    #[elem(patch = patch::background)]
     #[default(::NONE)]
     pub fill: Color,
+    #[elem(patch = patch::radius)]
     #[default(px(3))]
     pub radius: Val,
 }
 
-impl DropdownItem {
-    fn node(&self) -> Node {
-        Node {
-            width: percent(100),
-            height: self.height,
-            flex_direction: FlexDirection::Row,
-            align_items: AlignItems::Center,
-            padding: UiRect::axes(px(8), Val::ZERO),
-            border_radius: BorderRadius::all(self.radius),
-            ..default()
-        }
-    }
-}
+impl DropdownItem {}
 
-impl ElementVisual<BevyHost> for DropdownItem {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl DropdownItem {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            BackgroundColor(self.fill),
+            Node {
+                width: percent(100),
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                padding: UiRect::axes(px(8), Val::ZERO),
+                ..default()
+            },
             MenuItem,
             TabIndex(0),
             EntityCursor::System(SystemCursorIcon::Pointer),
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: DropdownItemField,
-    ) {
-        match field {
-            DropdownItemField::Fill => {
-                patch.insert(BackgroundColor(self.fill));
-            }
-            DropdownItemField::Height | DropdownItemField::Radius => {
-                patch.insert(self.node());
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/field.rs
+++ b/editor/moxie_ui/src/elements/field.rs
@@ -1,6 +1,6 @@
 //! What an inspector row is edited with.
 
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::feathers::controls::{
     FeathersNumberInput, FeathersTextInput,
     FeathersTextInputContainer, NumberFormat, NumberInputValue,
@@ -14,15 +14,20 @@ use bevy::ui::Checked;
 use bevy::ui_widgets::Checkbox as CheckboxBehavior;
 use bevy::window::SystemCursorIcon;
 use bevy_fynix::WorldEntityMut;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+use fynix::ui::Patch;
+
+use super::patch;
 
 /// A box that is ticked or not.
-#[element]
+#[element(build = Self::build)]
 pub struct CheckBox {
+    #[elem(patch = checked)]
     pub checked: bool,
+    #[elem(patch = patch::background)]
     #[default(Color::srgba(1.0, 1.0, 1.0, 0.08))]
     pub fill: Color,
+    #[elem(patch = mark)]
     #[default(Color::srgb(0.47, 0.86, 0.91))]
     pub mark: Color,
 }
@@ -32,56 +37,49 @@ pub struct CheckBox {
 #[derive(Component)]
 struct CheckMark;
 
-impl CheckBox {
-    fn tick(&self, entity: &mut impl WorldEntityMut) {
-        if self.checked {
-            entity.insert(Checked);
+/// Toggle the `Checked` marker and show or hide the inner square.
+pub(super) fn tick(checked: bool, entity: &mut impl WorldEntityMut) {
+    if checked {
+        entity.insert(Checked);
+    } else {
+        entity.remove::<Checked>();
+    }
+
+    let node = entity.id();
+    let world = entity.world_mut();
+    let Some(mark) = mark_node(world, node) else {
+        return;
+    };
+    if let Some(mut layout) = world.get_mut::<Node>(mark) {
+        layout.display = if checked {
+            Display::Flex
         } else {
-            entity.remove::<Checked>();
-        }
-
-        let node = entity.id();
-        let world = entity.world_mut();
-
-        let Some(mark) = self.mark_node(world, node) else {
-            return;
+            Display::None
         };
-        if let Some(mut layout) = world.get_mut::<Node>(mark) {
-            layout.display = if self.checked {
-                Display::Flex
-            } else {
-                Display::None
-            };
-        }
-    }
-
-    fn paint(&self, entity: &mut impl WorldEntityMut) {
-        let node = entity.id();
-        let world = entity.world_mut();
-
-        let Some(mark) = self.mark_node(world, node) else {
-            return;
-        };
-        world.entity_mut(mark).insert(BackgroundColor(self.mark));
-    }
-
-    /// The mark [`build_fields`](ElementVisual::build_fields) spawned,
-    /// found by its marker rather than by position: a box may be given
-    /// children of its own.
-    fn mark_node(
-        &self,
-        world: &World,
-        node: Entity,
-    ) -> Option<Entity> {
-        world
-            .get::<Children>(node)?
-            .iter()
-            .find(|&child| world.get::<CheckMark>(child).is_some())
     }
 }
 
-impl ElementVisual<BevyHost> for CheckBox {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+/// Paint the inner square.
+pub(super) fn paint(mark: Color, entity: &mut impl WorldEntityMut) {
+    let node = entity.id();
+    let world = entity.world_mut();
+    let Some(spot) = mark_node(world, node) else {
+        return;
+    };
+    world.entity_mut(spot).insert(BackgroundColor(mark));
+}
+
+/// The mark the build hook spawned, found by its marker rather than
+/// by position: a box may be given children of its own.
+fn mark_node(world: &World, node: Entity) -> Option<Entity> {
+    world
+        .get::<Children>(node)?
+        .iter()
+        .find(|&child| world.get::<CheckMark>(child).is_some())
+}
+
+impl CheckBox {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build
             .insert((
                 CheckboxBehavior,
@@ -108,151 +106,95 @@ impl ElementVisual<BevyHost> for CheckBox {
                 BackgroundColor(self.mark),
             ));
 
-        self.tick(build);
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: CheckBoxField,
-    ) {
-        match field {
-            CheckBoxField::Checked => self.tick(patch),
-            CheckBoxField::Fill => {
-                patch.insert(BackgroundColor(self.fill));
-            }
-            CheckBoxField::Mark => self.paint(patch),
-        }
+        tick(self.checked, build);
     }
 }
 
+fn checked(patch: &mut Patch<FynixHost>, checked: &bool) {
+    tick(*checked, patch);
+}
+
+fn mark(patch: &mut Patch<FynixHost>, mark: &Color) {
+    paint(*mark, patch);
+}
+
 /// A number, typed or dragged.
-#[element]
+#[element(build = Self::build)]
 pub struct NumberField {
+    #[elem(patch = number_format)]
     pub format: NumberFormat,
     /// What it shows. Pushed as an event rather than written as a
     /// component, so an input being typed into ignores it and a live
     /// edit wins.
+    #[elem(patch = number_value)]
     #[default(NumberInputValue::F32(0.0))]
     pub value: NumberInputValue,
+    #[elem(patch = patch::width)]
     #[default(px(80))]
     pub width: Val,
 }
 
-impl NumberField {
-    /// Feathers builds the input as a scene of its own: a container,
-    /// the two steppers, and the text in between.
-    fn scene(&self, entity: &mut impl WorldEntityMut) {
-        let format = self.format;
-        let scene = bsn! {
-            @FeathersNumberInput { @number_format: {format} }
-        };
-
-        if let Err(err) = entity.entity_mut().apply_scene(scene) {
-            error!("failed to build a number field: {err}");
-        }
-
-        // Widening the node feathers wrote, not replacing it: the
-        // container carries the row's height, padding and rim, and an
-        // input without them has nothing to type into.
-        if let Some(mut layout) =
-            entity.entity_mut().get_mut::<Node>()
-        {
-            layout.width = self.width;
-            layout.flex_grow = 0.0;
-        }
+/// Feathers builds the input as a scene of its own: a container, the
+/// two steppers, and the text in between. Widening the node it wrote,
+/// not replacing it - the container carries the row's height, padding
+/// and rim, and an input without them has nothing to type into.
+pub(super) fn number_scene(
+    format: NumberFormat,
+    width: Val,
+    entity: &mut impl WorldEntityMut,
+) {
+    let scene = bsn! {
+        @FeathersNumberInput { @number_format: {format} }
+    };
+    if let Err(err) = entity.entity_mut().apply_scene(scene) {
+        error!("failed to build a number field: {err}");
+    }
+    if let Some(mut layout) = entity.entity_mut().get_mut::<Node>() {
+        layout.width = width;
+        layout.flex_grow = 0.0;
     }
 }
 
-impl ElementVisual<BevyHost> for NumberField {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        self.scene(build);
+impl NumberField {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        number_scene(self.format, self.width, build);
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: NumberFieldField,
-    ) {
-        let node = patch.id();
+fn number_format(
+    patch: &mut Patch<FynixHost>,
+    format: &NumberFormat,
+) {
+    let width = patch
+        .entity_mut()
+        .get::<Node>()
+        .map(|node| node.width)
+        .unwrap_or(px(80));
+    number_scene(*format, width, patch);
+}
 
-        match field {
-            NumberFieldField::Format => self.scene(patch),
-            NumberFieldField::Value => {
-                patch.world.trigger(UpdateNumberInput {
-                    entity: node,
-                    value: self.value,
-                });
-            }
-            NumberFieldField::Width => {
-                if let Some(mut layout) =
-                    patch.entity_mut().get_mut::<Node>()
-                {
-                    layout.width = self.width;
-                }
-            }
-        }
-    }
+fn number_value(
+    patch: &mut Patch<FynixHost>,
+    value: &NumberInputValue,
+) {
+    let node = patch.id();
+    patch.world.trigger(UpdateNumberInput {
+        entity: node,
+        value: *value,
+    });
 }
 
 /// A single-line string, edited in place.
-#[element]
+#[element(build = Self::build)]
 pub struct TextField {
+    #[elem(patch = text_value)]
     pub value: String,
+    #[elem(patch = patch::width)]
     #[default(px(110))]
     pub width: Val,
 }
 
 impl TextField {
-    /// Feathers wants its own child entity for the editable text -
-    /// see the type's own docs - so this node is the container, and
-    /// the widget beneath it what actually holds [`EditableText`].
-    fn scene(&self, entity: &mut impl WorldEntityMut) {
-        let scene = bsn! {
-            @FeathersTextInputContainer
-            Children [
-                ( @FeathersTextInput )
-            ]
-        };
-
-        if let Err(err) = entity.entity_mut().apply_scene(scene) {
-            error!("failed to build a text field: {err}");
-        }
-
-        if let Some(mut layout) =
-            entity.entity_mut().get_mut::<Node>()
-        {
-            layout.width = self.width;
-            layout.flex_grow = 0.0;
-
-            // `FeathersTextInputContainer` reserves its left inset as
-            // a colorless 3px *border* rather than padding (room for
-            // a leading icon we never add), which leaves the
-            // background unpainted there and the left corners looking
-            // square next to the fully rounded right ones. Folding it
-            // into padding instead paints the background - and so the
-            // radius - all the way around.
-            layout.border = UiRect::ZERO;
-            layout.padding = UiRect::horizontal(px(3.0));
-        }
-
-        self.show(entity);
-    }
-
-    /// Writes `self.value` into the child [`EditableText`].
-    fn show(&self, entity: &mut impl WorldEntityMut) {
-        let node = entity.id();
-        let world = entity.world_mut();
-        let Some(text_input) = Self::text_input(world, node) else {
-            return;
-        };
-        if let Some(mut text) =
-            world.get_mut::<EditableText>(text_input)
-        {
-            text.editor_mut().set_text(&self.value);
-        }
-    }
-
     /// The child entity actually holding [`EditableText`], found by
     /// marker rather than position - the container may end up with
     /// other children later (an icon, say), and nothing here should
@@ -267,25 +209,63 @@ impl TextField {
     }
 }
 
-impl ElementVisual<BevyHost> for TextField {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        self.scene(build);
+/// Feathers wants its own child entity for the editable text - see
+/// the type's own docs - so this node is the container, and the
+/// widget beneath it what actually holds [`EditableText`].
+fn text_scene(
+    width: Val,
+    value: &str,
+    entity: &mut impl WorldEntityMut,
+) {
+    let scene = bsn! {
+        @FeathersTextInputContainer
+        Children [
+            ( @FeathersTextInput )
+        ]
+    };
+    if let Err(err) = entity.entity_mut().apply_scene(scene) {
+        error!("failed to build a text field: {err}");
     }
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TextFieldField,
-    ) {
-        match field {
-            TextFieldField::Value => self.show(patch),
-            TextFieldField::Width => {
-                if let Some(mut layout) =
-                    patch.entity_mut().get_mut::<Node>()
-                {
-                    layout.width = self.width;
-                }
-            }
-        }
+    if let Some(mut layout) = entity.entity_mut().get_mut::<Node>() {
+        layout.width = width;
+        layout.flex_grow = 0.0;
+
+        // `FeathersTextInputContainer` reserves its left inset as a
+        // colorless 3px *border* rather than padding (room for a
+        // leading icon we never add), which leaves the background
+        // unpainted there and the left corners looking square next to
+        // the fully rounded right ones. Folding it into padding
+        // instead paints the background - and so the radius - all the
+        // way around.
+        layout.border = UiRect::ZERO;
+        layout.padding = UiRect::horizontal(px(3.0));
     }
+
+    set_text(value, entity);
+}
+
+/// Write `value` into the child [`EditableText`].
+pub(super) fn set_text(
+    value: &str,
+    entity: &mut impl WorldEntityMut,
+) {
+    let node = entity.id();
+    let world = entity.world_mut();
+    let Some(input) = TextField::text_input(world, node) else {
+        return;
+    };
+    if let Some(mut text) = world.get_mut::<EditableText>(input) {
+        text.editor_mut().set_text(value);
+    }
+}
+
+impl TextField {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        text_scene(self.width, &self.value, build);
+    }
+}
+
+fn text_value(patch: &mut Patch<FynixHost>, value: &str) {
+    set_text(value, patch);
 }

--- a/editor/moxie_ui/src/elements/frame.rs
+++ b/editor/moxie_ui/src/elements/frame.rs
@@ -1,140 +1,76 @@
-use crate::reactive::BevyHost;
 use bevy::prelude::*;
-use bevy_fynix::WorldEntityMut;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// The sized, optionally filled container almost every other widget's
-/// root node turns out to be.
+/// root node turns out to be. `Host::spawn` already gives it a `Node`;
+/// every field writes one slice of that, so it needs no build hook.
 #[element]
 pub struct Frame {
+    #[elem(patch = patch::width)]
     pub width: Val,
+    #[elem(patch = patch::height)]
     pub height: Val,
     /// The floor `width`/`height` can shrink to. `Auto` floors a
     /// flex item at its own content's size, which can fight a
     /// percentage `width` above trying to shrink it further; `px(0)`
     /// lifts that floor.
+    #[elem(patch = patch::min_width)]
     pub min_width: Val,
+    #[elem(patch = patch::min_height)]
     pub min_height: Val,
     /// Absolute for a frame that places itself, with [`inset`] saying
     /// where.
     ///
     /// [`inset`]: Frame::inset
+    #[elem(patch = patch::position)]
     pub position: PositionType,
     /// How far each edge sits from the parent's, for an absolute
     /// frame. `Auto` on an edge leaves that one to the layout.
-    #[default(UiRect::all(auto()))]
+    #[default(::all(auto()))]
+    #[elem(patch = patch::inset)]
     pub inset: UiRect,
+    #[elem(patch = patch::direction)]
     pub direction: FlexDirection,
+    #[elem(patch = patch::flex_grow)]
     pub flex_grow: f32,
+    #[elem(patch = patch::flex_shrink)]
     pub flex_shrink: f32,
+    #[elem(patch = patch::align)]
     pub align: AlignItems,
+    #[elem(patch = patch::justify)]
     pub justify: JustifyContent,
+    #[elem(patch = patch::padding)]
     pub padding: UiRect,
+    #[elem(patch = patch::margin)]
     pub margin: UiRect,
+    #[elem(patch = patch::overflow)]
     pub overflow: Overflow,
     /// Between rows, and between columns: a row of things wants the
     /// second, a column the first.
-    #[default(Val::ZERO)]
+    #[default(::ZERO)]
+    #[elem(patch = patch::row_gap)]
     pub row_gap: Val,
-    #[default(Val::ZERO)]
+    #[default(::ZERO)]
+    #[elem(patch = patch::column_gap)]
     pub column_gap: Val,
-    #[default(Val::ZERO)]
+    #[default(::ZERO)]
+    #[elem(patch = patch::radius)]
     pub radius: Val,
     /// Transparent by default, for a frame that only wants the
     /// layout.
-    #[default(Color::NONE)]
+    #[default(::NONE)]
+    #[elem(patch = patch::background)]
     pub background: Color,
     /// `None` hides it, which is how a frame that depends on a size it
     /// has not measured yet avoids showing up at its intrinsic size
     /// for a frame.
+    #[elem(patch = patch::display)]
     pub display: Display,
     /// Where it sits in the window's stack, for a frame that has to
     /// be above what it does not sit inside. `None` leaves it in its
     /// parent's, where the tree already puts it.
+    #[elem(patch = patch::optional_z)]
     pub z: Option<i32>,
-}
-
-impl Frame {
-    fn node(&self) -> Node {
-        Node {
-            width: self.width,
-            height: self.height,
-            min_width: self.min_width,
-            min_height: self.min_height,
-            position_type: self.position,
-            left: self.inset.left,
-            right: self.inset.right,
-            top: self.inset.top,
-            bottom: self.inset.bottom,
-            flex_direction: self.direction,
-            flex_grow: self.flex_grow,
-            flex_shrink: self.flex_shrink,
-            align_items: self.align,
-            justify_content: self.justify,
-            padding: self.padding,
-            margin: self.margin,
-            overflow: self.overflow,
-            row_gap: self.row_gap,
-            column_gap: self.column_gap,
-            border_radius: BorderRadius::all(self.radius),
-            display: self.display,
-            ..default()
-        }
-    }
-}
-
-impl Frame {
-    /// Written whole, so that a frame going back into its parent's
-    /// stack loses the component rather than keeping a stale one.
-    fn stack(&self, entity: &mut impl WorldEntityMut) {
-        match self.z {
-            Some(z) => entity.insert(GlobalZIndex(z)),
-            None => entity.remove::<GlobalZIndex>(),
-        };
-    }
-}
-
-impl ElementVisual<BevyHost> for Frame {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        build.insert((self.node(), BackgroundColor(self.background)));
-
-        self.stack(build);
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: FrameField,
-    ) {
-        match field {
-            FrameField::Background => {
-                patch.insert(BackgroundColor(self.background));
-            }
-            // Every other field is one of `Node`'s, and writing the
-            // node whole is one insert rather than eight arms that
-            // each write a field of it.
-            FrameField::Z => self.stack(patch),
-            FrameField::Width
-            | FrameField::Height
-            | FrameField::MinWidth
-            | FrameField::MinHeight
-            | FrameField::Position
-            | FrameField::Inset
-            | FrameField::FlexGrow
-            | FrameField::FlexShrink
-            | FrameField::Direction
-            | FrameField::Align
-            | FrameField::Justify
-            | FrameField::Padding
-            | FrameField::Margin
-            | FrameField::Overflow
-            | FrameField::RowGap
-            | FrameField::ColumnGap
-            | FrameField::Radius
-            | FrameField::Display => {
-                patch.insert(self.node());
-            }
-        }
-    }
 }

--- a/editor/moxie_ui/src/elements/icon.rs
+++ b/editor/moxie_ui/src/elements/icon.rs
@@ -1,83 +1,51 @@
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::prelude::*;
 use bevy::ui::widget::ImageNode;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+use fynix::ui::Patch;
+
+use super::patch::{self, with};
 
 /// An image at a size of its own, which is what a [`Button`] shows.
 ///
 /// [`Button`]: super::Button
-#[element]
+#[element(build = Self::build)]
 pub struct Icon {
     /// Asset path.
+    #[elem(patch = image)]
     pub image: String,
+    #[elem(patch = color)]
     pub color: Color,
+    #[elem(patch = patch::icon_size)]
     #[default(px(11))]
     pub size: Val,
     /// Clockwise, in degrees.
+    #[elem(patch = rotation)]
     pub rotation: f32,
 }
 
+pub(super) fn icon_transform(rotation: f32) -> UiTransform {
+    UiTransform::from_rotation(Rot2::degrees(rotation))
+}
+
 impl Icon {
-    fn transform(&self) -> UiTransform {
-        UiTransform::from_rotation(Rot2::degrees(self.rotation))
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        // The handle and colour land through `image` / `color`; this
+        // just gives them an `ImageNode` to write into.
+        build.insert(ImageNode::default());
     }
 }
 
-impl ElementVisual<BevyHost> for Icon {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        let image = build.world.load_asset(self.image.clone());
+fn image(patch: &mut Patch<FynixHost>, image: &str) {
+    let handle = patch.world.load_asset(image.to_owned());
+    with::<ImageNode>(patch, move |img| img.image = handle);
+}
 
-        build.insert((
-            ImageNode {
-                image,
-                color: self.color,
-                ..default()
-            },
-            Node {
-                width: self.size,
-                height: self.size,
-                ..default()
-            },
-            self.transform(),
-        ));
-    }
+fn color(patch: &mut Patch<FynixHost>, color: &Color) {
+    with::<ImageNode>(patch, |img| img.color = *color);
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: IconField,
-    ) {
-        match field {
-            IconField::Image => {
-                let image =
-                    patch.world.load_asset(self.image.clone());
-
-                if let Some(mut node) =
-                    patch.entity_mut().get_mut::<ImageNode>()
-                {
-                    node.image = image;
-                }
-            }
-            IconField::Color => {
-                if let Some(mut image) =
-                    patch.entity_mut().get_mut::<ImageNode>()
-                {
-                    image.color = self.color;
-                }
-            }
-            IconField::Size => {
-                if let Some(mut layout) =
-                    patch.entity_mut().get_mut::<Node>()
-                {
-                    layout.width = self.size;
-                    layout.height = self.size;
-                }
-            }
-            IconField::Rotation => {
-                patch.insert(self.transform());
-            }
-        }
-    }
+fn rotation(patch: &mut Patch<FynixHost>, rotation: &f32) {
+    patch.insert(icon_transform(*rotation));
 }

--- a/editor/moxie_ui/src/elements/inspector.rs
+++ b/editor/moxie_ui/src/elements/inspector.rs
@@ -35,7 +35,7 @@ use crate::inspector::{
     inspect_value, single_value,
 };
 use crate::motion::MotionExt;
-use crate::reactive::{BevyHost, BevyUi, value_changed};
+use crate::reactive::{BevyUi, FynixHost, value_changed};
 use crate::theme::EditorTheme;
 
 /// Inspector for a [`Component`].
@@ -60,13 +60,13 @@ impl ComponentInspector {
     }
 }
 
-impl Composer<BevyHost> for ComponentInspector {
+impl Composer<FynixHost> for ComponentInspector {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let field = Field::new(self.entity, self.component);
         let built = field.clone();
         let depth = self.depth;
@@ -97,13 +97,13 @@ impl ResourceInspector {
     }
 }
 
-impl Composer<BevyHost> for ResourceInspector {
+impl Composer<FynixHost> for ResourceInspector {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let resource = self.resource;
 
         column(ui, px(4), entity_changed(resource), move |ui| {
@@ -124,13 +124,13 @@ pub struct EntityInspector {
     pub entity: Entity,
 }
 
-impl Composer<BevyHost> for EntityInspector {
+impl Composer<FynixHost> for EntityInspector {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let entity = self.entity;
 
         column(ui, px(8), components_changed(entity), move |ui| {
@@ -173,13 +173,13 @@ struct AddComponent {
     entity: Entity,
 }
 
-impl Composer<BevyHost> for AddComponent {
+impl Composer<FynixHost> for AddComponent {
     type Element = DropdownMenu;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, DropdownMenu> {
+    ) -> ElementHandle<FynixHost, DropdownMenu> {
         let entity = self.entity;
         let theme = ui.theme;
         let options = addable(ui.world, entity);
@@ -361,7 +361,7 @@ fn resource_entity(
 /// old bindings quietly re-pointed.
 fn entity_changed(
     resource: TypeId,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool {
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool {
     value_changed(move |world, _| resource_entity(world, resource))
 }
 
@@ -372,7 +372,7 @@ fn entity_changed(
 /// rebuilds when one is added, removed, or the entity goes.
 fn components_changed(
     entity: Entity,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool {
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool {
     value_changed(move |world, _| inspectable(world, entity))
 }
 
@@ -456,9 +456,9 @@ fn humanize(name: &str) -> String {
 fn column(
     ui: &mut BevyUi,
     gap: Val,
-    changed: impl ChangedFn<BevyHost>,
-    build: impl BuildFn<BevyHost>,
-) -> ElementHandle<BevyHost, Frame> {
+    changed: impl ChangedFn<FynixHost>,
+    build: impl BuildFn<FynixHost>,
+) -> ElementHandle<FynixHost, Frame> {
     ui.elem(elem!(
         Frame,
         width = percent(100),
@@ -476,6 +476,6 @@ fn column(
 /// [`InspectorFields`]' own business, with its own watcher for that.
 fn presence_changed(
     field: Field,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool {
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool {
     value_changed(move |world, _| field.exists(world))
 }

--- a/editor/moxie_ui/src/elements/label.rs
+++ b/editor/moxie_ui/src/elements/label.rs
@@ -1,88 +1,94 @@
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::feathers::theme::ThemedText;
 use bevy::prelude::*;
-use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use bevy_fynix::WorldEntityMut;
+use fynix::element::element;
+use fynix::ui::Patch;
+
+use super::patch::with;
 
 /// A theme-inheriting text label.
-#[element]
+#[element(build = Self::build)]
 pub struct Label {
+    #[elem(patch = text)]
     pub text: String,
+    #[elem(patch = size)]
     #[default(12.0)]
     pub size: f32,
     /// `None` leaves the colour to the theme.
+    #[elem(patch = color)]
     pub color: Option<Color>,
+    #[elem(patch = bold)]
     pub bold: bool,
+    #[elem(patch = wrap)]
     #[default(true)]
     pub wrap: bool,
 }
 
-impl Label {
-    fn font(&self) -> TextFont {
-        TextFont {
-            font_size: FontSize::Px(self.size),
-            weight: if self.bold {
-                FontWeight::BOLD
-            } else {
-                FontWeight::NORMAL
-            },
-            ..default()
-        }
-    }
-
-    fn layout(&self) -> TextLayout {
-        TextLayout {
-            linebreak: if self.wrap {
-                LineBreak::WordBoundary
-            } else {
-                LineBreak::NoWrap
-            },
-            ..default()
-        }
+fn font(size: f32, bold: bool) -> TextFont {
+    TextFont {
+        font_size: FontSize::Px(size),
+        weight: if bold {
+            FontWeight::BOLD
+        } else {
+            FontWeight::NORMAL
+        },
+        ..default()
     }
 }
 
-impl ElementVisual<BevyHost> for Label {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+fn layout(wrap: bool) -> TextLayout {
+    TextLayout {
+        linebreak: if wrap {
+            LineBreak::WordBoundary
+        } else {
+            LineBreak::NoWrap
+        },
+        ..default()
+    }
+}
+
+impl Label {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             Text::new(self.text.clone()),
-            self.font(),
-            self.layout(),
+            font(self.size, self.bold),
+            layout(self.wrap),
         ));
 
-        // A colour of its own opts out of the theme's.
-        match self.color {
-            Some(color) => build.insert(TextColor(color)),
-            None => build.insert(ThemedText),
-        };
+        set_color(self.color, build);
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: LabelField,
-    ) {
-        match field {
-            LabelField::Text => {
-                if let Some(mut text) =
-                    patch.entity_mut().get_mut::<Text>()
-                {
-                    text.0.clone_from(&self.text);
-                }
-            }
-            LabelField::Size | LabelField::Bold => {
-                patch.insert(self.font());
-            }
-            LabelField::Wrap => {
-                patch.insert(self.layout());
-            }
-            LabelField::Color => {
-                match self.color {
-                    Some(color) => patch.insert(TextColor(color)),
-                    None => patch.insert(ThemedText),
-                };
-            }
-        }
-    }
+fn text(patch: &mut Patch<FynixHost>, text: &String) {
+    with::<Text>(patch, |t| t.0.clone_from(text));
+}
+
+fn size(patch: &mut Patch<FynixHost>, size: &f32) {
+    with::<TextFont>(patch, |f| f.font_size = FontSize::Px(*size));
+}
+
+fn bold(patch: &mut Patch<FynixHost>, bold: &bool) {
+    let weight = if *bold {
+        FontWeight::BOLD
+    } else {
+        FontWeight::NORMAL
+    };
+    with::<TextFont>(patch, move |f| f.weight = weight);
+}
+
+fn wrap(patch: &mut Patch<FynixHost>, wrap: &bool) {
+    patch.insert(layout(*wrap));
+}
+
+fn color(patch: &mut Patch<FynixHost>, color: &Option<Color>) {
+    set_color(*color, patch);
+}
+
+/// A colour of its own opts out of the theme's.
+fn set_color(color: Option<Color>, entity: &mut impl WorldEntityMut) {
+    match color {
+        Some(color) => entity.insert(TextColor(color)),
+        None => entity.insert(ThemedText),
+    };
 }

--- a/editor/moxie_ui/src/elements/overlay.rs
+++ b/editor/moxie_ui/src/elements/overlay.rs
@@ -1,59 +1,32 @@
-use crate::reactive::BevyHost;
-use bevy::picking::Pickable;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// A node the size of the window, for something that positions itself
 /// against the window rather than against a parent.
-#[element]
+#[element(build = Self::build)]
 pub struct Overlay {
     /// Whether the pointer sees it. Off unless it is there to catch
     /// something: seen, it is the target of every press, and a press
     /// on it takes focus from whatever is underneath.
+    #[elem(patch = patch::overlay_pickable)]
     pub catches: bool,
+    #[elem(patch = patch::z_index)]
     pub z: i32,
 }
 
 impl Overlay {
-    /// It never blocks. What it catches, it catches by being seen.
-    fn pickable(&self) -> Pickable {
-        Pickable {
-            should_block_lower: false,
-            is_hoverable: self.catches,
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for Overlay {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        build.insert((
-            Node {
-                position_type: PositionType::Absolute,
-                left: px(0),
-                top: px(0),
-                width: percent(100),
-                height: percent(100),
-                ..default()
-            },
-            self.pickable(),
-            GlobalZIndex(self.z),
-        ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: OverlayField,
-    ) {
-        match field {
-            OverlayField::Catches => {
-                patch.insert(self.pickable());
-            }
-            OverlayField::Z => {
-                patch.insert(GlobalZIndex(self.z));
-            }
-        }
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        build.insert(Node {
+            position_type: PositionType::Absolute,
+            left: px(0),
+            top: px(0),
+            width: percent(100),
+            height: percent(100),
+            ..default()
+        });
     }
 }

--- a/editor/moxie_ui/src/elements/panel.rs
+++ b/editor/moxie_ui/src/elements/panel.rs
@@ -1,82 +1,49 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// What a docked window fills its area with: the whole of it, and
 /// scrolling if what it holds does not fit.
-#[element]
+#[element(build = Self::build)]
 pub struct Panel {
+    #[elem(patch = patch::direction)]
     pub direction: FlexDirection,
     /// Stretch, by default, which is what fills a docked area.
+    #[elem(patch = patch::align)]
     pub align: AlignItems,
+    #[elem(patch = patch::justify)]
     pub justify: JustifyContent,
+    #[elem(patch = patch::padding)]
     pub padding: UiRect,
     /// Between rows, and between columns: a row of things wants the
     /// second, a column the first.
+    #[elem(patch = patch::row_gap)]
     #[default(Val::ZERO)]
     pub row_gap: Val,
+    #[elem(patch = patch::column_gap)]
     #[default(Val::ZERO)]
     pub column_gap: Val,
+    #[elem(patch = patch::panel_scrolls)]
     pub scrolls: bool,
     /// How far down it is scrolled, for a panel whose scroll follows
     /// something else.
+    #[elem(patch = patch::panel_scroll)]
     pub scroll: f32,
 }
 
 impl Panel {
-    fn node(&self) -> Node {
-        Node {
-            flex_grow: 1.0,
-            min_width: px(0),
-            min_height: px(0),
-            flex_direction: self.direction,
-            align_items: self.align,
-            justify_content: self.justify,
-            padding: self.padding,
-            row_gap: self.row_gap,
-            column_gap: self.column_gap,
-            overflow: if self.scrolls {
-                Overflow::scroll_y()
-            } else {
-                Overflow::clip()
-            },
-            ..default()
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for Panel {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            ScrollPosition(Vec2::new(0.0, self.scroll)),
+            Node {
+                flex_grow: 1.0,
+                min_width: px(0),
+                min_height: px(0),
+                ..default()
+            },
+            ScrollPosition::default(),
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: PanelField,
-    ) {
-        match field {
-            PanelField::Scroll => {
-                if let Some(mut scroll) =
-                    patch.entity_mut().get_mut::<ScrollPosition>()
-                {
-                    scroll.0.y = self.scroll;
-                }
-            }
-            PanelField::Direction
-            | PanelField::Align
-            | PanelField::Justify
-            | PanelField::Padding
-            | PanelField::RowGap
-            | PanelField::ColumnGap
-            | PanelField::Scrolls => {
-                patch.insert(self.node());
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/patch.rs
+++ b/editor/moxie_ui/src/elements/patch.rs
@@ -1,0 +1,197 @@
+//! Shared `#[elem(patch = ...)]` writers.
+//!
+//! A field writer only sees its own value, so the pattern is: an
+//! element's `#[element(build = ...)]` hook inserts the component
+//! whole, and a writer here reaches that component back and moves the
+//! one field. These are the writers many elements share; the ones
+//! specific to a single element live beside it.
+
+use bevy::ecs::component::Mutable;
+use bevy::prelude::*;
+use bevy_fynix::WorldEntityMut as _;
+use fynix::ui::Patch;
+
+use crate::reactive::FynixHost;
+
+/// Move one field of component `C` on the node a patch landed on, if
+/// the node still carries one.
+pub(super) fn with<C: Component<Mutability = Mutable>>(
+    patch: &mut Patch<FynixHost>,
+    f: impl FnOnce(&mut C),
+) {
+    if let Some(mut component) = patch.entity_mut().get_mut::<C>() {
+        f(&mut component);
+    }
+}
+
+/// As [`with`], for [`Node`] - the component almost every writer
+/// touches.
+pub(super) fn node(
+    patch: &mut Patch<FynixHost>,
+    f: impl FnOnce(&mut Node),
+) {
+    with(patch, f);
+}
+
+/// One `Node` field, set from a reference to a matching value.
+macro_rules! set {
+    ($name:ident, $ty:ty, |$n:ident, $v:ident| $body:expr) => {
+        pub(super) fn $name(patch: &mut Patch<FynixHost>, $v: &$ty) {
+            node(patch, |$n| $body);
+        }
+    };
+}
+
+set!(width, Val, |n, v| n.width = *v);
+set!(height, Val, |n, v| n.height = *v);
+set!(min_width, Val, |n, v| n.min_width = *v);
+set!(min_height, Val, |n, v| n.min_height = *v);
+set!(max_width, Val, |n, v| n.max_width = *v);
+set!(row_gap, Val, |n, v| n.row_gap = *v);
+set!(column_gap, Val, |n, v| n.column_gap = *v);
+set!(radius, Val, |n, v| n.border_radius = BorderRadius::all(*v));
+set!(flex_grow, f32, |n, v| n.flex_grow = *v);
+set!(flex_shrink, f32, |n, v| n.flex_shrink = *v);
+set!(padding, UiRect, |n, v| n.padding = *v);
+set!(margin, UiRect, |n, v| n.margin = *v);
+set!(direction, FlexDirection, |n, v| n.flex_direction = *v);
+set!(align, AlignItems, |n, v| n.align_items = *v);
+set!(justify, JustifyContent, |n, v| n.justify_content = *v);
+set!(position, PositionType, |n, v| n.position_type = *v);
+set!(display, Display, |n, v| n.display = *v);
+set!(overflow, Overflow, |n, v| n.overflow = *v);
+set!(top, Val, |n, v| n.top = *v);
+set!(left, Val, |n, v| n.left = *v);
+
+/// The four edge insets, from one [`UiRect`].
+pub(super) fn inset(patch: &mut Patch<FynixHost>, v: &UiRect) {
+    node(patch, |n| {
+        n.left = v.left;
+        n.right = v.right;
+        n.top = v.top;
+        n.bottom = v.bottom;
+    });
+}
+
+pub(super) fn background(patch: &mut Patch<FynixHost>, v: &Color) {
+    patch.insert(BackgroundColor(*v));
+}
+
+pub(super) fn border_color(patch: &mut Patch<FynixHost>, v: &Color) {
+    patch.insert(BorderColor::all(*v));
+}
+
+pub(super) fn z_index(patch: &mut Patch<FynixHost>, v: &i32) {
+    patch.insert(GlobalZIndex(*v));
+}
+
+/// `None` drops the override, leaving the node in its parent's stack.
+pub(super) fn optional_z(
+    patch: &mut Patch<FynixHost>,
+    v: &Option<i32>,
+) {
+    match v {
+        Some(z) => {
+            patch.insert(GlobalZIndex(*z));
+        }
+        None => {
+            patch.remove::<GlobalZIndex>();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// shared, but shaped by one element's layout
+// ---------------------------------------------------------------------
+
+/// A square icon: one value drives both dimensions.
+pub(super) fn icon_size(patch: &mut Patch<FynixHost>, size: &Val) {
+    node(patch, |n| {
+        n.width = *size;
+        n.height = *size;
+    });
+}
+
+/// An overlay never blocks; what it catches, it catches by being seen.
+pub(super) fn overlay_pickable(
+    patch: &mut Patch<FynixHost>,
+    catches: &bool,
+) {
+    patch.insert(Pickable {
+        should_block_lower: false,
+        is_hoverable: *catches,
+    });
+}
+
+pub(super) fn panel_scroll(
+    patch: &mut Patch<FynixHost>,
+    scroll: &f32,
+) {
+    with::<ScrollPosition>(patch, |pos| pos.0.y = *scroll);
+}
+
+pub(super) fn panel_scrolls(
+    patch: &mut Patch<FynixHost>,
+    scrolls: &bool,
+) {
+    let overflow = if *scrolls {
+        Overflow::scroll_y()
+    } else {
+        Overflow::clip()
+    };
+    node(patch, move |n| n.overflow = overflow);
+}
+
+fn axis(on: bool) -> OverflowAxis {
+    if on {
+        OverflowAxis::Scroll
+    } else {
+        OverflowAxis::Visible
+    }
+}
+
+pub(super) fn scroll_x(patch: &mut Patch<FynixHost>, on: &bool) {
+    let a = axis(*on);
+    node(patch, move |n| n.overflow.x = a);
+}
+
+pub(super) fn scroll_y(patch: &mut Patch<FynixHost>, on: &bool) {
+    let a = axis(*on);
+    node(patch, move |n| n.overflow.y = a);
+}
+
+/// A time-axis label's `left`, plus the centring its position implies:
+/// the leftmost mark reads flush, the rest centre over their tick.
+pub(super) fn time_label_x(patch: &mut Patch<FynixHost>, x: &Val) {
+    let x = *x;
+    let centred = !matches!(x, Val::Px(p) if p <= 0.0);
+    node(patch, move |n| {
+        n.left = x;
+        n.justify_content = if centred {
+            JustifyContent::Center
+        } else {
+            JustifyContent::FlexStart
+        };
+        n.padding =
+            UiRect::left(if centred { Val::ZERO } else { px(3) });
+    });
+}
+
+/// A timeline track, sized to its duration on both `width` and its
+/// own min.
+pub(super) fn track_width(patch: &mut Patch<FynixHost>, width: &Val) {
+    let width = *width;
+    node(patch, move |n| {
+        n.width = width;
+        n.min_width = width;
+    });
+}
+
+/// A timeline clip's border thickens when it is selected.
+pub(super) fn selected(
+    patch: &mut Patch<FynixHost>,
+    selected: &bool,
+) {
+    let w = if *selected { 2 } else { 1 };
+    node(patch, move |n| n.border = UiRect::all(px(w)));
+}

--- a/editor/moxie_ui/src/elements/playhead.rs
+++ b/editor/moxie_ui/src/elements/playhead.rs
@@ -1,54 +1,33 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// The playhead line, positioned by the editor's playhead system.
-#[element]
+#[element(build = Self::build)]
 pub struct PlayheadLine {
-    pub left: f32,
+    #[elem(patch = patch::left)]
+    pub left: Val,
 }
 
 impl PlayheadLine {
-    fn node(&self) -> Node {
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(0),
-            bottom: px(0),
-            left: px(self.left),
-            width: px(2),
-            flex_grow: 1.0,
-            ..default()
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for PlayheadLine {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         let color = build.theme.palette.orange;
 
         build.insert((
-            self.node(),
+            Node {
+                position_type: PositionType::Absolute,
+                top: px(0),
+                bottom: px(0),
+                width: px(2),
+                flex_grow: 1.0,
+                ..default()
+            },
             ZIndex(10),
             BackgroundColor(color),
             Pickable::IGNORE,
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: PlayheadLineField,
-    ) {
-        match field {
-            PlayheadLineField::Left => {
-                if let Some(mut node) =
-                    patch.entity_mut().get_mut::<Node>()
-                {
-                    node.left = px(self.left);
-                }
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/scroll_area.rs
+++ b/editor/moxie_ui/src/elements/scroll_area.rs
@@ -1,111 +1,68 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy::ui_widgets::ScrollArea as ScrollAreaBehavior;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// A sized container with real, interactive scrolling - trackpad and
 /// mouse-wheel input actually move it (`ScrollAreaBehavior`), not just
 /// a clipped overflow a caller has to drive by hand.
-#[element]
+#[element(build = Self::build)]
 pub struct ScrollArea {
+    #[elem(patch = patch::width)]
     pub width: Val,
+    #[elem(patch = patch::height)]
     pub height: Val,
     /// How much of its parent's remaining space this area claims -
     /// almost always `1.0` for one that should fill what's left.
+    #[elem(patch = patch::flex_grow)]
     #[default(0.0)]
     pub flex_grow: f32,
+    #[elem(patch = patch::direction)]
     #[default(::Column)]
     pub direction: FlexDirection,
+    #[elem(patch = patch::align)]
     pub align: AlignItems,
+    #[elem(patch = patch::justify)]
     pub justify: JustifyContent,
+    #[elem(patch = patch::padding)]
     pub padding: UiRect,
     /// Between rows, and between columns: a row of things wants the
     /// second, a column the first.
+    #[elem(patch = patch::row_gap)]
     #[default(::ZERO)]
     pub row_gap: Val,
+    #[elem(patch = patch::column_gap)]
     #[default(::ZERO)]
     pub column_gap: Val,
+    #[elem(patch = patch::radius)]
     #[default(::ZERO)]
     pub radius: Val,
+    #[elem(patch = patch::background)]
     #[default(::NONE)]
     pub background: Color,
+    #[elem(patch = patch::scroll_x)]
     #[default(true)]
     pub scroll_x: bool,
+    #[elem(patch = patch::scroll_y)]
     #[default(true)]
     pub scroll_y: bool,
 }
 
 impl ScrollArea {
-    fn node(&self) -> Node {
-        Node {
-            width: self.width,
-            height: self.height,
-            flex_grow: self.flex_grow,
-            // `min: 0` lets the area shrink below its content instead
-            // of forcing its parent to grow around it - without this
-            // there is nothing left to scroll.
-            min_width: px(0),
-            min_height: px(0),
-            flex_direction: self.direction,
-            align_items: self.align,
-            justify_content: self.justify,
-            padding: self.padding,
-            row_gap: self.row_gap,
-            column_gap: self.column_gap,
-            border_radius: BorderRadius::all(self.radius),
-            overflow: Overflow {
-                x: axis(self.scroll_x),
-                y: axis(self.scroll_y),
-            },
-            ..default()
-        }
-    }
-}
-
-fn axis(scrolls: bool) -> OverflowAxis {
-    if scrolls {
-        OverflowAxis::Scroll
-    } else {
-        OverflowAxis::Visible
-    }
-}
-
-impl ElementVisual<BevyHost> for ScrollArea {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        // `min: 0` lets the area shrink below its content instead of
+        // forcing its parent to grow around it - without it there is
+        // nothing left to scroll.
         build.insert((
-            self.node(),
-            BackgroundColor(self.background),
+            Node {
+                min_width: px(0),
+                min_height: px(0),
+                ..default()
+            },
             ScrollAreaBehavior,
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: ScrollAreaField,
-    ) {
-        match field {
-            ScrollAreaField::Background => {
-                patch.insert(BackgroundColor(self.background));
-            }
-            // Every other field is one of `Node`'s, and writing it
-            // whole is one insert rather than an arm apiece.
-            ScrollAreaField::Width
-            | ScrollAreaField::Height
-            | ScrollAreaField::FlexGrow
-            | ScrollAreaField::Direction
-            | ScrollAreaField::Align
-            | ScrollAreaField::Justify
-            | ScrollAreaField::Padding
-            | ScrollAreaField::RowGap
-            | ScrollAreaField::ColumnGap
-            | ScrollAreaField::Radius
-            | ScrollAreaField::ScrollX
-            | ScrollAreaField::ScrollY => {
-                patch.insert(self.node());
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/segmented_control.rs
+++ b/editor/moxie_ui/src/elements/segmented_control.rs
@@ -12,7 +12,7 @@ use fynix::ui::ElementHandle;
 use fynix::{elem, val};
 
 use super::{Frame, Label, SegmentButton};
-use crate::reactive::{BevyHost, BevyUi};
+use crate::reactive::{BevyUi, FynixHost};
 
 /// A 3-way (or more) radio, one option filled solid - bevy_feathers'
 /// own `RoundedCorners`/`ButtonVariant::Primary` pattern: only the
@@ -27,7 +27,7 @@ pub struct SegmentedControl<F> {
     pub on_select: F,
 }
 
-impl<F> Composer<BevyHost> for SegmentedControl<F>
+impl<F> Composer<FynixHost> for SegmentedControl<F>
 where
     F: Fn(usize, &mut Commands) + Clone + Send + Sync + 'static,
 {
@@ -36,7 +36,7 @@ where
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let Self {
             options,
             selected,

--- a/editor/moxie_ui/src/elements/tab.rs
+++ b/editor/moxie_ui/src/elements/tab.rs
@@ -1,25 +1,27 @@
 //! A leaf's tab bar: the strip, the scrolling row, and one tab.
 
-use crate::reactive::BevyHost;
+use crate::reactive::{FynixBuild, FynixHost};
 use bevy::feathers::cursor::EntityCursor;
 use bevy::prelude::*;
 use bevy::window::SystemCursorIcon;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+use fynix::ui::Patch;
 
+use super::patch::{self, with};
 use super::{ButtonElem, Icon, Label};
 use crate::widgets::dock::{DockTab, DockTabRow, TAB_HEIGHT, TabId};
 
 /// The strip across the top of a leaf.
-#[element]
+#[element(build = Self::build)]
 pub struct TabBar {
+    #[elem(patch = patch::background)]
     #[default(Color::srgba(1.0, 1.0, 1.0, 0.03))]
     pub background: Color,
 }
 
-impl ElementVisual<BevyHost> for TabBar {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl TabBar {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             Node {
                 flex_direction: FlexDirection::Row,
@@ -40,26 +42,14 @@ impl ElementVisual<BevyHost> for TabBar {
             BackgroundColor(self.background),
         ));
     }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TabBarField,
-    ) {
-        match field {
-            TabBarField::Background => {
-                patch.insert(BackgroundColor(self.background));
-            }
-        }
-    }
 }
 
 /// What the tabs themselves sit in, which scrolls when they overflow.
-#[element]
+#[element(build = Self::build)]
 pub struct TabRow;
 
-impl ElementVisual<BevyHost> for TabRow {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl TabRow {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             DockTabRow,
             Node {
@@ -75,14 +65,6 @@ impl ElementVisual<BevyHost> for TabRow {
             ScrollPosition::default(),
         ));
     }
-
-    fn patch_fields(
-        &self,
-        _patch: &mut Patch<BevyHost>,
-        field: TabRowField,
-    ) {
-        match field {}
-    }
 }
 
 /// One tab: its icon, its name, and the button that closes it.
@@ -90,7 +72,7 @@ impl ElementVisual<BevyHost> for TabRow {
 /// Which tab is active is a field rather than a rebuild, because
 /// switching tabs must not take the drag in progress or the row's
 /// scroll offset with it.
-#[element]
+#[element(build = Self::build)]
 pub struct Tab {
     #[elem(child)]
     pub icon: Option<Icon>,
@@ -98,33 +80,40 @@ pub struct Tab {
     pub label: Label,
     #[elem(child)]
     pub close: Option<ButtonElem>,
+    #[elem(patch = window_id)]
     pub window_id: String,
+    #[elem(patch = tab_id)]
     #[default(TabId(0))]
     pub tab: TabId,
+    #[elem(patch = active)]
     pub active: bool,
+    #[elem(patch = fill)]
     #[default(Color::srgba(1.0, 1.0, 1.0, 0.06))]
     pub fill: Color,
 }
 
-impl Tab {
-    fn background(&self) -> BackgroundColor {
-        BackgroundColor(if self.active {
-            self.fill
-        } else {
-            Color::NONE
-        })
-    }
+/// The tab's fill, kept on the node whether or not it is showing, so
+/// [`patch_active`] can put it back when the tab becomes active
+/// again.
+#[derive(Component, Clone, Copy)]
+pub(super) struct TabFill(pub(super) Color);
+
+pub(super) fn tab_background(
+    active: bool,
+    fill: Color,
+) -> BackgroundColor {
+    BackgroundColor(if active { fill } else { Color::NONE })
 }
 
-impl ElementVisual<BevyHost> for Tab {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+impl Tab {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
             DockTab {
                 window_id: self.window_id.clone(),
                 tab_id: self.tab,
             },
-            // A tab is dragged, so it says so at rest. The drag
-            // itself swaps in `Grabbing` through `OverrideCursor`.
+            // A tab is dragged, so it says so at rest. The drag itself
+            // swaps in `Grabbing` through `OverrideCursor`.
             EntityCursor::System(SystemCursorIcon::Grab),
             Node {
                 flex_direction: FlexDirection::Row,
@@ -136,25 +125,36 @@ impl ElementVisual<BevyHost> for Tab {
                 border_radius: BorderRadius::all(px(4)),
                 ..default()
             },
-            self.background(),
+            TabFill(self.fill),
+            tab_background(self.active, self.fill),
         ));
     }
+}
 
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TabField,
-    ) {
-        match field {
-            TabField::Active | TabField::Fill => {
-                patch.insert(self.background());
-            }
-            TabField::WindowId | TabField::Tab => {
-                patch.insert(DockTab {
-                    window_id: self.window_id.clone(),
-                    tab_id: self.tab,
-                });
-            }
-        }
+fn active(patch: &mut Patch<FynixHost>, active: &bool) {
+    let fill = patch
+        .entity_mut()
+        .get::<TabFill>()
+        .map(|f| f.0)
+        .unwrap_or(Color::NONE);
+    patch.insert(tab_background(*active, fill));
+}
+
+fn fill(patch: &mut Patch<FynixHost>, fill: &Color) {
+    let active = patch
+        .entity_mut()
+        .get::<BackgroundColor>()
+        .is_some_and(|bg| bg.0 != Color::NONE);
+    patch.insert(TabFill(*fill));
+    if active {
+        patch.insert(BackgroundColor(*fill));
     }
+}
+
+fn window_id(patch: &mut Patch<FynixHost>, window_id: &String) {
+    with::<DockTab>(patch, |d| d.window_id.clone_from(window_id));
+}
+
+fn tab_id(patch: &mut Patch<FynixHost>, tab: &TabId) {
+    with::<DockTab>(patch, |d| d.tab_id = *tab);
 }

--- a/editor/moxie_ui/src/elements/tab.rs
+++ b/editor/moxie_ui/src/elements/tab.rs
@@ -97,6 +97,12 @@ pub struct Tab {
 #[derive(Component, Clone, Copy)]
 pub(super) struct TabFill(pub(super) Color);
 
+/// Marks the tab as active. Kept on the node so [`fill`] knows whether
+/// to show a new fill without reading it back off [`BackgroundColor`],
+/// which an active tab with a [`Color::NONE`] fill reports as inactive.
+#[derive(Component)]
+pub(super) struct TabActive;
+
 pub(super) fn tab_background(
     active: bool,
     fill: Color,
@@ -127,6 +133,9 @@ impl Tab {
             TabFill(self.fill),
             tab_background(self.active, self.fill),
         ));
+        if self.active {
+            build.insert(TabActive);
+        }
     }
 }
 
@@ -137,13 +146,15 @@ fn active(patch: &mut Patch<FynixHost>, active: &bool) {
         .map(|f| f.0)
         .unwrap_or(Color::NONE);
     patch.insert(tab_background(*active, fill));
+    if *active {
+        patch.insert(TabActive);
+    } else {
+        patch.remove::<TabActive>();
+    }
 }
 
 fn fill(patch: &mut Patch<FynixHost>, fill: &Color) {
-    let active = patch
-        .entity_mut()
-        .get::<BackgroundColor>()
-        .is_some_and(|bg| bg.0 != Color::NONE);
+    let active = patch.entity_mut().contains::<TabActive>();
     patch.insert(TabFill(*fill));
     if active {
         patch.insert(BackgroundColor(*fill));
@@ -156,4 +167,37 @@ fn window_id(patch: &mut Patch<FynixHost>, window_id: &String) {
 
 fn tab_id(patch: &mut Patch<FynixHost>, tab: &TabId) {
     with::<DockTab>(patch, |d| d.tab_id = *tab);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::EditorTheme;
+
+    /// An active tab whose fill is [`Color::NONE`] still picks up a
+    /// later non-transparent fill: `fill` reads [`TabActive`], not the
+    /// (transparent) [`BackgroundColor`] left behind by activation.
+    #[test]
+    fn fill_updates_active_tab_with_none_fill() {
+        let mut world = World::new();
+        let theme = EditorTheme::default();
+
+        let node = world
+            .spawn((TabFill(Color::NONE), tab_background(true, Color::NONE)))
+            .id();
+
+        let green = Color::srgb(0.0, 1.0, 0.0);
+
+        {
+            let mut patch = Patch::<FynixHost>::new(&mut world, node, &theme);
+            active(&mut patch, &true);
+        }
+        {
+            let mut patch = Patch::<FynixHost>::new(&mut world, node, &theme);
+            fill(&mut patch, &green);
+        }
+
+        assert_eq!(world.get::<BackgroundColor>(node).unwrap().0, green);
+        assert_eq!(world.get::<TabFill>(node).unwrap().0, green);
+    }
 }

--- a/editor/moxie_ui/src/elements/tab.rs
+++ b/editor/moxie_ui/src/elements/tab.rs
@@ -93,8 +93,7 @@ pub struct Tab {
 }
 
 /// The tab's fill, kept on the node whether or not it is showing, so
-/// [`patch_active`] can put it back when the tab becomes active
-/// again.
+/// [`active`] can put it back when the tab becomes active again.
 #[derive(Component, Clone, Copy)]
 pub(super) struct TabFill(pub(super) Color);
 

--- a/editor/moxie_ui/src/elements/tab.rs
+++ b/editor/moxie_ui/src/elements/tab.rs
@@ -183,21 +183,29 @@ mod tests {
         let theme = EditorTheme::default();
 
         let node = world
-            .spawn((TabFill(Color::NONE), tab_background(true, Color::NONE)))
+            .spawn((
+                TabFill(Color::NONE),
+                tab_background(true, Color::NONE),
+            ))
             .id();
 
         let green = Color::srgb(0.0, 1.0, 0.0);
 
         {
-            let mut patch = Patch::<FynixHost>::new(&mut world, node, &theme);
+            let mut patch =
+                Patch::<FynixHost>::new(&mut world, node, &theme);
             active(&mut patch, &true);
         }
         {
-            let mut patch = Patch::<FynixHost>::new(&mut world, node, &theme);
+            let mut patch =
+                Patch::<FynixHost>::new(&mut world, node, &theme);
             fill(&mut patch, &green);
         }
 
-        assert_eq!(world.get::<BackgroundColor>(node).unwrap().0, green);
+        assert_eq!(
+            world.get::<BackgroundColor>(node).unwrap().0,
+            green
+        );
         assert_eq!(world.get::<TabFill>(node).unwrap().0, green);
     }
 }

--- a/editor/moxie_ui/src/elements/time_label.rs
+++ b/editor/moxie_ui/src/elements/time_label.rs
@@ -1,61 +1,32 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
 
 use super::Label;
+use super::patch;
 
 /// A time reading on the time axis, placing above the mark it reads
 /// for.
-#[element]
+#[element(build = Self::build)]
 pub struct TimeLabel {
     #[elem(child)]
     pub label: Label,
     /// Pixels from the time axis's left edge.
-    pub x: f32,
+    #[elem(patch = patch::time_label_x)]
+    pub x: Val,
 }
 
 impl TimeLabel {
-    fn node(&self) -> Node {
-        Node {
-            position_type: PositionType::Absolute,
-            left: px(self.x),
-            top: px(1),
-            width: px(0),
-            justify_content: if self.centred() {
-                JustifyContent::Center
-            } else {
-                JustifyContent::FlexStart
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        build.insert((
+            Node {
+                position_type: PositionType::Absolute,
+                top: px(1),
+                width: px(0),
+                ..default()
             },
-            padding: UiRect::left(if self.centred() {
-                Val::ZERO
-            } else {
-                px(3)
-            }),
-            ..default()
-        }
-    }
-
-    fn centred(&self) -> bool {
-        self.x > 0.0
-    }
-}
-
-impl ElementVisual<BevyHost> for TimeLabel {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        build.insert((self.node(), Pickable::IGNORE));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TimeLabelField,
-    ) {
-        match field {
-            TimeLabelField::X => {
-                patch.insert(self.node());
-            }
-        }
+            Pickable::IGNORE,
+        ));
     }
 }

--- a/editor/moxie_ui/src/elements/time_tick.rs
+++ b/editor/moxie_ui/src/elements/time_tick.rs
@@ -1,56 +1,36 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// One mark on the time axis.
-#[element]
+#[element(build = Self::build)]
 pub struct TimeTick {
     /// Pixels from the time axis's left edge.
-    pub x: f32,
+    #[elem(patch = patch::left)]
+    pub x: Val,
     /// Grown upward from the time axis's bottom edge, so marks of
     /// different lengths share a baseline.
-    #[default(4.0)]
-    pub height: f32,
+    #[elem(patch = patch::height)]
+    #[default(px(4))]
+    pub height: Val,
+    #[elem(patch = patch::background)]
     #[default(Color::srgba(1.0, 1.0, 1.0, 0.25))]
     pub color: Color,
 }
 
 impl TimeTick {
-    fn node(&self) -> Node {
-        Node {
-            position_type: PositionType::Absolute,
-            left: px(self.x),
-            bottom: px(0),
-            width: px(1),
-            height: px(self.height),
-            ..default()
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for TimeTick {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            BackgroundColor(self.color),
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: px(0),
+                width: px(1),
+                ..default()
+            },
             Pickable::IGNORE,
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TimeTickField,
-    ) {
-        match field {
-            TimeTickField::Color => {
-                patch.insert(BackgroundColor(self.color));
-            }
-            TimeTickField::X | TimeTickField::Height => {
-                patch.insert(self.node());
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/timeline_action.rs
+++ b/editor/moxie_ui/src/elements/timeline_action.rs
@@ -1,87 +1,60 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::feathers::cursor::EntityCursor;
 use bevy::prelude::*;
 use bevy::ui_widgets::Button as ButtonBehavior;
 use bevy::window::SystemCursorIcon;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
 
 use super::Label;
+use super::patch;
 
 /// One action's clip on the timeline: a colored, absolutely
 /// positioned, bordered hit area, its name (if any) pinned to its
 /// top-left corner exactly like [`TimelineBlock`](super::TimelineBlock)'s -
 /// clipped rather than measured, so a bar too narrow for it just
 /// shows nothing instead of overflowing its neighbor.
-#[element]
+#[element(build = Self::build)]
 pub struct TimelineAction {
     /// Blank when the action has no name of its own.
     #[elem(child)]
     pub label: Label,
-    pub top: f32,
-    pub left: f32,
-    pub width: f32,
-    pub height: f32,
+    #[elem(patch = patch::top)]
+    pub top: Val,
+    #[elem(patch = patch::left)]
+    pub left: Val,
+    #[elem(patch = patch::width)]
+    pub width: Val,
+    #[elem(patch = patch::height)]
+    pub height: Val,
+    #[elem(patch = patch::background)]
     #[default(Color::NONE)]
     pub fill: Color,
+    #[elem(patch = patch::border_color)]
     #[default(Color::NONE)]
     pub border: Color,
     /// Thickens the border - the caller still chooses `border`'s
     /// color (the theme's accent, typically).
+    #[elem(patch = patch::selected)]
     pub selected: bool,
 }
 
 impl TimelineAction {
-    fn node(&self) -> Node {
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(self.top),
-            left: px(self.left),
-            width: px(self.width),
-            height: px(self.height),
-            padding: UiRect::new(px(4), Val::ZERO, px(2), Val::ZERO),
-            overflow: Overflow::clip(),
-            border: UiRect::all(px(if self.selected {
-                2
-            } else {
-                1
-            })),
-            ..default()
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for TimelineAction {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            BackgroundColor(self.fill),
-            BorderColor::all(self.border),
+            Node {
+                position_type: PositionType::Absolute,
+                padding: UiRect::new(
+                    px(4),
+                    Val::ZERO,
+                    px(2),
+                    Val::ZERO,
+                ),
+                overflow: Overflow::clip(),
+                ..default()
+            },
             ButtonBehavior,
             EntityCursor::System(SystemCursorIcon::Pointer),
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TimelineActionField,
-    ) {
-        match field {
-            TimelineActionField::Top
-            | TimelineActionField::Left
-            | TimelineActionField::Width
-            | TimelineActionField::Height
-            | TimelineActionField::Selected => {
-                patch.insert(self.node());
-            }
-            TimelineActionField::Fill => {
-                patch.insert(BackgroundColor(self.fill));
-            }
-            TimelineActionField::Border => {
-                patch.insert(BorderColor::all(self.border));
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/timeline_block.rs
+++ b/editor/moxie_ui/src/elements/timeline_block.rs
@@ -1,13 +1,13 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::feathers::cursor::EntityCursor;
 use bevy::prelude::*;
 use bevy::ui_widgets::Button as ButtonBehavior;
 use bevy::window::SystemCursorIcon;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
 
 use super::Label;
+use super::patch;
 
 /// A block's header box: an absolutely positioned, bordered container
 /// with its label pinned to its top-left corner, left padded to leave
@@ -22,68 +22,46 @@ use super::Label;
 /// Clickable exactly like [`TimelineAction`](super::TimelineAction):
 /// it carries the same [`ButtonBehavior`], so a click fires
 /// `Activate` the caller can select it on.
-#[element]
+#[element(build = Self::build)]
 pub struct TimelineBlock {
     #[elem(child)]
     pub label: Label,
-    pub top: f32,
-    pub left: f32,
-    pub width: f32,
-    pub height: f32,
+    #[elem(patch = patch::top)]
+    pub top: Val,
+    #[elem(patch = patch::left)]
+    pub left: Val,
+    #[elem(patch = patch::width)]
+    pub width: Val,
+    #[elem(patch = patch::height)]
+    pub height: Val,
+    #[elem(patch = patch::background)]
     #[default(Color::NONE)]
     pub background: Color,
+    #[elem(patch = patch::border_color)]
     #[default(Color::NONE)]
     pub border: Color,
 }
 
 impl TimelineBlock {
-    fn node(&self) -> Node {
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(self.top),
-            left: px(self.left),
-            width: px(self.width),
-            height: px(self.height),
-            // The label sits in normal flow rather than absolute, so
-            // this padding alone is what pins it to the top-left
-            // corner - left wide enough to clear the chevron drawn
-            // over it.
-            padding: UiRect::new(px(16), Val::ZERO, px(2), Val::ZERO),
-            border: UiRect::all(px(1)),
-            ..default()
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for TimelineBlock {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
         build.insert((
-            self.node(),
-            BackgroundColor(self.background),
-            BorderColor::all(self.border),
+            Node {
+                position_type: PositionType::Absolute,
+                // The label sits in normal flow rather than absolute,
+                // so this padding alone is what pins it to the
+                // top-left corner - left wide enough to clear the
+                // chevron drawn over it.
+                padding: UiRect::new(
+                    px(16),
+                    Val::ZERO,
+                    px(2),
+                    Val::ZERO,
+                ),
+                border: UiRect::all(px(1)),
+                ..default()
+            },
             ButtonBehavior,
             EntityCursor::System(SystemCursorIcon::Pointer),
         ));
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TimelineBlockField,
-    ) {
-        match field {
-            TimelineBlockField::Top
-            | TimelineBlockField::Left
-            | TimelineBlockField::Width
-            | TimelineBlockField::Height => {
-                patch.insert(self.node());
-            }
-            TimelineBlockField::Background => {
-                patch.insert(BackgroundColor(self.background));
-            }
-            TimelineBlockField::Border => {
-                patch.insert(BorderColor::all(self.border));
-            }
-        }
     }
 }

--- a/editor/moxie_ui/src/elements/timeline_track.rs
+++ b/editor/moxie_ui/src/elements/timeline_track.rs
@@ -1,44 +1,26 @@
-use crate::reactive::BevyHost;
+use crate::reactive::FynixBuild;
 use bevy::prelude::*;
 use bevy_fynix::WorldEntityMut as _;
-use fynix::element::{ElementVisual, element};
-use fynix::ui::{Build, Patch};
+use fynix::element::element;
+
+use super::patch;
 
 /// The scrubbable timeline track: a plain node sized to the track's
 /// duration. The consuming app resolves its own pixels per second
 /// scale and passes the result as `width`, so a clip at time `t` sits
 /// at `t * pixels_per_second` from the track's left edge.
-#[element]
+#[element(build = Self::build)]
 pub struct TimelineTrack {
-    pub width: f32,
+    #[elem(patch = patch::track_width)]
+    pub width: Val,
 }
 
 impl TimelineTrack {
-    fn node(&self) -> Node {
-        Node {
+    fn build(&self, build: &mut FynixBuild<'_, Self>) {
+        build.insert(Node {
             position_type: PositionType::Relative,
-            width: px(self.width),
-            min_width: px(self.width),
             height: percent(100),
             ..default()
-        }
-    }
-}
-
-impl ElementVisual<BevyHost> for TimelineTrack {
-    fn build_fields(&self, build: &mut Build<BevyHost, Self>) {
-        build.insert(self.node());
-    }
-
-    fn patch_fields(
-        &self,
-        patch: &mut Patch<BevyHost>,
-        field: TimelineTrackField,
-    ) {
-        match field {
-            TimelineTrackField::Width => {
-                patch.insert(self.node());
-            }
-        }
+        });
     }
 }

--- a/editor/moxie_ui/src/fold.rs
+++ b/editor/moxie_ui/src/fold.rs
@@ -25,7 +25,7 @@ use crate::elements::{
     IconCursor, TintButton,
 };
 use crate::icons;
-use crate::reactive::{BevyHost, BevyUi, component_changed_on};
+use crate::reactive::{BevyUi, FynixHost, component_changed_on};
 
 /// The chevron's rotation, clockwise from the asset's resting
 /// up-pointing orientation. Right when shut, down when open.
@@ -76,9 +76,9 @@ pub enum FoldsOn {
 /// All this owns is the click that toggles, the chevron that turns,
 /// the body that goes, and the rail marking how deep that body sits.
 pub struct Foldable<
-    S: StyledElem<Host = BevyHost, Element = ButtonElem>,
-    B: BuildFn<BevyHost>,
-    H: for<'u, 'a> FnOnce(ElementMut<'u, 'a, BevyHost, ButtonElem>),
+    S: StyledElem<Host = FynixHost, Element = ButtonElem>,
+    B: BuildFn<FynixHost>,
+    H: for<'u, 'a> FnOnce(ElementMut<'u, 'a, FynixHost, ButtonElem>),
     T: Fn(&mut World, bool) + Clone + Send + Sync + 'static,
 > {
     /// Anything built on a [`ButtonElem`]. Under [`FoldsOn::Header`]
@@ -105,11 +105,11 @@ pub struct Foldable<
     pub on_toggle: T,
 }
 
-impl<S, B, H, T> Composer<BevyHost> for Foldable<S, B, H, T>
+impl<S, B, H, T> Composer<FynixHost> for Foldable<S, B, H, T>
 where
-    S: StyledElem<Host = BevyHost, Element = ButtonElem>,
-    B: BuildFn<BevyHost>,
-    H: for<'u, 'a> FnOnce(ElementMut<'u, 'a, BevyHost, ButtonElem>),
+    S: StyledElem<Host = FynixHost, Element = ButtonElem>,
+    B: BuildFn<FynixHost>,
+    H: for<'u, 'a> FnOnce(ElementMut<'u, 'a, FynixHost, ButtonElem>),
     T: Fn(&mut World, bool) + Clone + Send + Sync + 'static,
 {
     type Element = Frame;
@@ -117,7 +117,7 @@ where
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let Self {
             header,
             folds_on,
@@ -249,7 +249,7 @@ where
 /// Makes `button` the one that folds `node`, turning its chevron with
 /// the state and mirroring the result through `on_toggle`.
 fn folds<T>(
-    button: &mut ElementMut<BevyHost, ButtonElem>,
+    button: &mut ElementMut<FynixHost, ButtonElem>,
     node: Entity,
     on_toggle: T,
 ) where

--- a/editor/moxie_ui/src/inspector.rs
+++ b/editor/moxie_ui/src/inspector.rs
@@ -32,7 +32,7 @@ use moxie_asset::AssetKindAppExt;
 
 use crate::elements::{Frame, Label};
 use crate::fold;
-use crate::reactive::{BevyHost, BevyUi};
+use crate::reactive::{BevyUi, FynixHost};
 pub use field::Field;
 pub(crate) use tree::single_value;
 pub use tree::{InspectorFields, Section};
@@ -193,7 +193,7 @@ impl<S: Source + ?Sized> SourceExt for S {}
 /// about a source depends on the node asking.
 pub fn when_changed(
     source: &dyn Source,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -281,13 +281,13 @@ pub struct FieldRow<F: FnOnce(&mut BevyUi)> {
     pub value: F,
 }
 
-impl<F: FnOnce(&mut BevyUi)> Composer<BevyHost> for FieldRow<F> {
+impl<F: FnOnce(&mut BevyUi)> Composer<FynixHost> for FieldRow<F> {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let Self {
             label,
             color,

--- a/editor/moxie_ui/src/inspector/enums.rs
+++ b/editor/moxie_ui/src/inspector/enums.rs
@@ -39,7 +39,7 @@ use crate::elements::{
 };
 use crate::icons;
 use crate::motion::MotionExt;
-use crate::reactive::{BevyHost, BevyUi};
+use crate::reactive::{BevyUi, FynixHost};
 use crate::theme::EditorTheme;
 
 /// Every variant of `value`'s type, if it is an enum at all.
@@ -161,13 +161,13 @@ pub(super) struct VariantPicker<'a> {
     pub pick: bool,
 }
 
-impl Composer<BevyHost> for VariantPicker<'_> {
+impl Composer<FynixHost> for VariantPicker<'_> {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let Self {
             source,
             variants,

--- a/editor/moxie_ui/src/inspector/tree.rs
+++ b/editor/moxie_ui/src/inspector/tree.rs
@@ -23,7 +23,7 @@ use super::{Field, FieldRow, ReflectInspect, enums};
 use crate::elements::{ButtonElem, Frame, Icon, Label, TintButton};
 use crate::fold::{CHEVRON_SHUT, Foldable, FoldsOn};
 use crate::icons;
-use crate::reactive::{BevyHost, BevyUi};
+use crate::reactive::{BevyUi, FynixHost};
 
 /// Which of an inspected entity's sections were folded shut, keyed by
 /// component and path. A section absent here is open. Goes when the
@@ -249,7 +249,7 @@ pub(crate) fn single_value(
 /// touched the component.
 fn shape_changed(
     field: Field,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool {
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool {
     let mut seen_tick: Option<Tick> = None;
     let mut seen_shape: Option<Vec<Entry>> = None;
     move |WorldNodeRef { world, .. }| {
@@ -276,13 +276,13 @@ pub struct InspectorFields {
     pub depth: u32,
 }
 
-impl Composer<BevyHost> for InspectorFields {
+impl Composer<FynixHost> for InspectorFields {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let walked = self.root.clone();
         let depth = self.depth;
 
@@ -462,13 +462,13 @@ pub struct Section<F> {
     pub section: (Entity, TypeId, String),
 }
 
-impl<F: BuildFn<BevyHost>> Composer<BevyHost> for Section<F> {
+impl<F: BuildFn<FynixHost>> Composer<FynixHost> for Section<F> {
     type Element = Frame;
 
     fn compose(
         self,
         ui: &mut BevyUi,
-    ) -> ElementHandle<BevyHost, Frame> {
+    ) -> ElementHandle<FynixHost, Frame> {
         let Self {
             name,
             body,
@@ -509,7 +509,7 @@ impl<F: BuildFn<BevyHost>> Composer<BevyHost> for Section<F> {
             on_header: |_: ElementMut<
                 '_,
                 '_,
-                BevyHost,
+                FynixHost,
                 ButtonElem,
             >| {},
             body,

--- a/editor/moxie_ui/src/lib.rs
+++ b/editor/moxie_ui/src/lib.rs
@@ -18,6 +18,9 @@ pub mod reactive;
 pub mod theme;
 pub mod widgets;
 
+/// The backend `#[element]` builds against by default.
+pub use reactive::{FynixBuild, FynixHost};
+
 use bevy::feathers::FeathersPlugins;
 use bevy::feathers::dark_theme::create_dark_theme;
 use bevy::feathers::theme::UiTheme;

--- a/editor/moxie_ui/src/motion.rs
+++ b/editor/moxie_ui/src/motion.rs
@@ -2,7 +2,7 @@
 //! than spelling it out. Each takes the field by cursor, so one of
 //! them serves every widget with a colour in the right place.
 
-use crate::reactive::BevyHost;
+use crate::reactive::FynixHost;
 use crate::theme::EditorTheme;
 use bevy::color::Mix;
 use bevy::picking::events::{
@@ -52,8 +52,8 @@ impl Lit for Option<Color> {
 
 /// Lights a field under the cursor, reading its base out of the
 /// kernel's own table. Only [`ElementMut`] offers this, not
-/// [`Build`]: a node running its own
-/// `build_fields` has no entry there yet.
+/// [`Build`]: a node running its own `#[element(build = ...)]` hook
+/// has no entry there yet.
 pub trait MotionExt<E: Element<<Self as LitFrom<E>>::Host>>:
     LitFrom<E>
 {
@@ -85,10 +85,9 @@ pub trait MotionExt<E: Element<<Self as LitFrom<E>>::Host>>:
 }
 
 /// As [`MotionExt`], but given the base explicitly instead of
-/// reading it out of the kernel's table, for
-/// [`build_fields`](fynix::element::ElementVisual::build_fields)
-/// whose node has no entry there yet. Both [`ElementMut`] and
-/// [`Build`] offer this.
+/// reading it out of the kernel's table, for a
+/// `#[element(build = ...)]` hook whose node has no entry there yet.
+/// Both [`ElementMut`] and [`Build`] offer this.
 pub trait LitFrom<E: Element<Self::Host>> {
     type Host: Host;
 
@@ -120,8 +119,8 @@ pub trait LitFrom<E: Element<Self::Host>> {
         T: Lit;
 }
 
-impl<E: Element<BevyHost> + Send + Sync> MotionExt<E>
-    for ElementMut<'_, '_, BevyHost, E>
+impl<E: Element<FynixHost> + Send + Sync> MotionExt<E>
+    for ElementMut<'_, '_, FynixHost, E>
 {
     fn lit<P, T>(
         &mut self,
@@ -158,10 +157,10 @@ impl<E: Element<BevyHost> + Send + Sync> MotionExt<E>
     }
 }
 
-impl<E: Element<BevyHost> + Send + Sync> LitFrom<E>
-    for ElementMut<'_, '_, BevyHost, E>
+impl<E: Element<FynixHost> + Send + Sync> LitFrom<E>
+    for ElementMut<'_, '_, FynixHost, E>
 {
-    type Host = BevyHost;
+    type Host = FynixHost;
 
     fn theme(&self) -> &EditorTheme {
         self.ui.theme
@@ -205,10 +204,10 @@ impl<E: Element<BevyHost> + Send + Sync> LitFrom<E>
     }
 }
 
-impl<E: Element<BevyHost> + Send + Sync> LitFrom<E>
-    for Build<'_, BevyHost, E>
+impl<E: Element<FynixHost> + Send + Sync> LitFrom<E>
+    for Build<'_, FynixHost, E>
 {
-    type Host = BevyHost;
+    type Host = FynixHost;
 
     fn theme(&self) -> &EditorTheme {
         self.theme
@@ -263,7 +262,7 @@ fn on_lit<T, E, P, Target>(
 ) -> &mut T
 where
     T: OnExt<E, EditorTheme>,
-    E: Element<BevyHost> + Send + Sync,
+    E: Element<FynixHost> + Send + Sync,
     P: FieldPath<Source = E, Target = Target>,
     Target: Lit,
 {

--- a/editor/moxie_ui/src/reactive.rs
+++ b/editor/moxie_ui/src/reactive.rs
@@ -3,7 +3,7 @@
 //! The kernel itself is [`bevy_fynix`]; what lives here is the
 //! predicates the editor asks it to watch, none of which know
 //! anything about the kernel: each is a
-//! `FnMut(WorldNodeRef<BevyHost>) -> bool` that answers "has this changed
+//! `FnMut(WorldNodeRef<FynixHost>) -> bool` that answers "has this changed
 //! since I last looked".
 
 use bevy::ecs::change_detection::{ComponentTicks, Tick};
@@ -18,14 +18,17 @@ pub use bevy_fynix::{FynixSet, watch_root};
 use crate::theme::EditorTheme;
 
 /// Fixes [`bevy_fynix::host::BevyHost`]'s theme to [`EditorTheme`].
-pub type BevyHost = bevy_fynix::host::BevyHost<EditorTheme>;
+pub type FynixHost = bevy_fynix::host::BevyHost<EditorTheme>;
+/// [`fynix::ui::Build`] against [`FynixHost`], for an element's own
+/// `fn build`.
+pub type FynixBuild<'a, E> = fynix::ui::Build<'a, FynixHost, E>;
 pub type BevyUi<'a> = bevy_fynix::BevyUi<'a, EditorTheme>;
 pub type FynixPlugin = bevy_fynix::FynixPlugin<EditorTheme>;
 
 /// Fires when `R` changed since the last poll. Also fires on the first
 /// poll, so a binding starts out in sync with the world.
 pub fn resource_changed<R: Resource>()
--> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+-> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -51,7 +54,7 @@ pub fn resource_changed<R: Resource>()
 /// instead.
 pub fn structure_changed<R: Resource, K>(
     project: impl Fn(&R) -> K + Send + Sync + 'static,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static
@@ -77,7 +80,7 @@ where
 /// closure, since a predicate only has `&World` to scan with.
 pub fn value_changed<T>(
     read: impl Fn(&World, Entity) -> T + Send + Sync + 'static,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static
@@ -99,7 +102,7 @@ where
 /// Rides the tick. Reach for [`value_changed`] when the value itself
 /// is what matters.
 pub fn component_changed<C: Component>()
--> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+-> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -115,7 +118,7 @@ pub fn component_changed<C: Component>()
 /// Same, for `C` on some other entity than the node.
 pub fn component_changed_on<C: Component>(
     entity: Entity,
-) -> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+) -> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {
@@ -150,7 +153,7 @@ pub(crate) fn tick_changed(
 
 /// Fires when the current `S` differs from the last poll.
 pub fn state_changed<S: States>()
--> impl for<'w> FnMut(WorldNodeRef<'w, BevyHost>) -> bool
+-> impl for<'w> FnMut(WorldNodeRef<'w, FynixHost>) -> bool
 + Send
 + Sync
 + 'static {


### PR DESCRIPTION
Removes the `ElementVisual` trait.

- Now users can treat each field with more fine grained control via the `#[elem(patch = <fn>)]` attribute.
- The patch functions will only receive the associated field rather than the entire element's struct. This opens doors to better fine grained controlled transitions!
- This also promotes code reuse with similar patch fields across different elements!
- The `#[element]` attribute also takes in additional argument:
  - `#[element(build = <fn>)]` to set the build function (otherwise it'll be left blank, allowing the build phase to be skipped completely if unnecessary!)
  - `#[element(host = <ty>)]` to override the default `crate::FynixHost` type
- New `ElementBase` trait for create an element with `Theme`! (tho it's unused right now, will follow up with a PR!)

## Build Flow

1. Element is created using `ElementBase`.
2. Styling kicks in.
3. Build function kicks in (if it exists).
4. Patches for each field kicks in.

## Example of how to create an element (the before & after)!

### Before

```rs
#[element]
pub struct Icon {
    pub image: String,
    pub color: Color,
    #[default(px(11))]
    pub size: Val,
    pub rotation: f32,
}

impl ElementVisual<BevyHost> for Icon {
        build.insert((
            ImageNode {
                image,
                color: self.color,
                ..default()
            },
            Node {
                width: self.size,
                height: self.size,
                ..default()
            },
            self.transform(),
        ));
    }

    fn patch_fields(&self, patch: &mut Patch<BevyHost>, field: IconField) {
        match field {
            IconField::Image => { /* load_asset + get_mut::<ImageNode>() */ }
            IconField::Color => { /* get_mut::<ImageNode>() */ }
            IconField::Size => { /* get_mut::<Node>(): width + height */ }
            IconField::Rotation => patch.insert(self.transform()),
        }
    }
}
```

### After

```rs
#[element(build = Self::build)]
pub struct Icon {
    #[elem(patch = image)]
    pub image: String,

    #[elem(patch = color)]
    pub color: Color,

    #[elem(patch = patch::icon_size)]
    #[default(px(11))]
    pub size: Val,

    #[elem(patch = rotation)]
    pub rotation: f32,
}

impl Icon {
    fn build(&self, build: &mut FynixBuild<'_, Self>) {
        build.insert(ImageNode::default());
    }
}

fn image(patch: &mut Patch<FynixHost>, image: &str) {
    let handle = patch.world.load_asset(image.to_owned());
    with::<ImageNode>(patch, move |img| img.image = handle);
}

fn color(patch: &mut Patch<FynixHost>, color: &Color) {
    with::<ImageNode>(patch, |img| img.color = *color);
}

fn rotation(patch: &mut Patch<FynixHost>, rotation: &f32) {
    patch.insert(icon_transform(*rotation));
}
```