### PR TITLE
Port the remaining moxie-branch changes to the shared crates

### DIFF
--- a/crates/bevy_motiongfx/README.md
+++ b/crates/bevy_motiongfx/README.md
@@ -57,8 +57,7 @@ fn build_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     // Spawn the timeline.
     commands.spawn(motiongfx.add_timeline(timeline));
@@ -94,8 +93,7 @@ fn build_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     // Spawn the timeline.
     commands.spawn(motiongfx.add_timeline(timeline));
@@ -117,8 +115,9 @@ fn build_timeline(
 ) {
     // Build the timeline.
     let mut b = motiongfx.create_builder();
-    // Add tracks here...
-    let timeline = b.compile();
+    // Add actions here...
+    let track = TrackFragment::new().compile();
+    let timeline = b.compile(track);
 
     // Spawn the timeline with a controller.
     commands.spawn((

--- a/crates/bevy_motiongfx/src/scene/backend.rs
+++ b/crates/bevy_motiongfx/src/scene/backend.rs
@@ -5,7 +5,7 @@
 use alloc::boxed::Box;
 
 use bevy_asset::uuid::Uuid;
-use bevy_reflect::TypePath;
+use bevy_reflect::{Reflect, TypePath};
 use bevy_transform::components::Transform;
 use motiongfx::prelude::*;
 use motiongfx_scene::prelude::*;
@@ -15,6 +15,23 @@ use serde::{Deserialize, Serialize};
 use crate::scene::id::{EntityUid, SceneUid};
 use crate::scene::value_pool::ValuePool;
 use crate::world::BevyWorld;
+
+/// The [`FieldRef`] a [`FieldAccessor`] resolves to once registered
+/// through [`SceneRegistryExt::register_reflected_field`] - same
+/// name-building rule
+/// ([`SceneRegistry::register_field_with_key`](motiongfx_scene::registry::SceneRegistry::register_field_with_key)),
+/// exposed so callers building [`ActionCmd`]s
+/// by hand (an editor, a scene author) can name a field the same way
+/// the registry does, without duplicating the `TypeName::new(S::type_path())`
+/// pairing themselves.
+pub fn field_ref<S: TypePath, T>(
+    field_acc: FieldAccessor<S, T>,
+) -> FieldRef {
+    FieldRef::new(
+        TypeName::new(S::type_path()),
+        field_acc.field.field_path(),
+    )
+}
 
 /// The concrete [`SceneBackend`] for Bevy.
 pub struct Backend;
@@ -32,23 +49,50 @@ impl SceneBackend for Backend {
 pub type BackendRegistry = SceneRegistry<Backend>;
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+    Reflect,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
 )]
+#[reflect(Debug, PartialEq, Hash)]
 pub enum AnimOp {
     /// Sets the field directly to the action's value.
     To,
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+    Reflect,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
 )]
+#[reflect(Debug, PartialEq, Hash)]
 pub enum AnimInterp {
     Linear,
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+    Reflect,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
 )]
+#[reflect(Debug, PartialEq, Hash)]
 pub enum AnimEase {
     Linear,
     CubicEaseInOut,

--- a/crates/bevy_motiongfx/src/scene/id.rs
+++ b/crates/bevy_motiongfx/src/scene/id.rs
@@ -41,6 +41,7 @@ use tracing::error;
 )]
 #[reflect(Component, Hash, PartialEq)]
 #[serde(transparent)]
+#[require(Name = Name("Unamed Entity".into()))]
 pub struct EntityUid(Uuid);
 
 impl EntityUid {

--- a/crates/bevy_motiongfx/src/scene/id.rs
+++ b/crates/bevy_motiongfx/src/scene/id.rs
@@ -41,7 +41,7 @@ use tracing::error;
 )]
 #[reflect(Component, Hash, PartialEq)]
 #[serde(transparent)]
-#[require(Name = Name("Unamed Entity".into()))]
+#[require(Name = Name("Unnamed Entity".into()))]
 pub struct EntityUid(Uuid);
 
 impl EntityUid {

--- a/crates/bevy_motiongfx/tests/asset.rs
+++ b/crates/bevy_motiongfx/tests/asset.rs
@@ -54,6 +54,7 @@ fn cube_scene_deserializes() {
                         action.subject
                     );
                 }
+                Node::Draft { .. } => {}
             }
         }
     }

--- a/crates/motiongfx/Cargo.toml
+++ b/crates/motiongfx/Cargo.toml
@@ -30,5 +30,5 @@ workspace = true
 
 [features]
 default = ["std", "tracing"]
-tracing = ["dep:tracing"]
 std = ["motiongfx_interp/std"]
+tracing = ["dep:tracing"]

--- a/crates/motiongfx/README.md
+++ b/crates/motiongfx/README.md
@@ -66,8 +66,7 @@ let frag = action.play(s(1));
 // See "Track Ordering" section for composing fragments.
 let track = frag.compile();
 
-b.add_tracks(track);
-let mut timeline = b.compile();
+let mut timeline = b.compile(track);
 
 // Bake must run once before sampling.
 timeline.bake_actions(&registry, &world);
@@ -171,8 +170,7 @@ let frag = action.play(s(1));
 let track = frag.compile();
 
 // Add the track and compile into a Timeline.
-b.add_tracks(track);
-let timeline = b.compile();
+let timeline = b.compile(track);
 ```
 
 ### Bake and Sample
@@ -279,14 +277,6 @@ You can join us on the [Voxell discord server](https://discord.gg/Mhnyp6VYEQ).
 
 - [Motion Canvas](https://motioncanvas.io/)
 - [Manim](https://www.manim.community/)
-
-## Version Matrix
-
-| Bevy    | MotionGfx  |
-| ------- | ---------- |
-| 0.19    | 0.3        |
-| 0.18    | 0.2        |
-| 0.17    | 0.1        |
 
 ## License
 

--- a/crates/motiongfx/benches/action_storage.rs
+++ b/crates/motiongfx/benches/action_storage.rs
@@ -6,13 +6,13 @@
 //! delta is attributable purely to the action-storage backend.
 //!
 //! Three phases of the animation loop are measured separately:
-//!   * `build`  — construct + compile a timeline (insertion into store)
-//!   * `bake`   — recompute all segments from subject start values
-//!   * `scrub`  — full-playback queue+sample sweep (the per-frame path)
+//!   * `build`: construct + compile a timeline (insertion into store)
+//!   * `bake`: recompute all segments from subject start values
+//!   * `scrub`: full-playback queue+sample sweep (the per-frame path)
 //!
 //! Each phase runs twice: a single-type scene (`f32`, one pipeline) and
 //! a `mixed_*` scene (four distinct value types, four pipelines) that
-//! stresses per-type dispatch and — in bevy ECS — archetype width.
+//! stresses per-type dispatch and (in bevy ECS) archetype width.
 //!
 //! Run (see the module docs / your notes for baseline comparison):
 //!   cargo bench -p motiongfx
@@ -85,8 +85,7 @@ fn build_timeline(
         })
         .collect::<Vec<_>>();
 
-    builder.add_tracks(fragments.ord_all().compile());
-    builder.compile()
+    builder.compile(fragments.ord_all().compile())
 }
 
 fn bench_build(c: &mut Criterion) {
@@ -180,7 +179,7 @@ fn bench_scrub(c: &mut Criterion) {
 // Mixed-type scene.
 //
 // The benches above use a single value type (`f32`), i.e. one pipeline
-// and one column set — the best case for ECS (a single archetype). Real
+// and one column set, the best case for ECS (a single archetype). Real
 // scenes animate many value types. `Widget` carries four distinct types
 // animated concurrently, producing four pipelines / four heterogeneous
 // column sets in typarena and a four-wide archetype in bevy ECS, which
@@ -262,7 +261,7 @@ fn make_mixed_world(n: u64) -> MixedWorld {
 }
 
 /// Build a timeline with `n` widgets, each animating all four typed
-/// fields over a 1s clip — `4 * n` actions across four pipelines.
+/// fields over a 1s clip, `4 * n` actions across four pipelines.
 fn build_mixed(
     registry: &mut Registry,
     n: u64,
@@ -318,8 +317,7 @@ fn build_mixed(
         })
         .collect::<Vec<_>>();
 
-    builder.add_tracks(fragments.ord_all().compile());
-    builder.compile()
+    builder.compile(fragments.ord_all().compile())
 }
 
 fn bench_mixed_build(c: &mut Criterion) {

--- a/crates/motiongfx/docs/world.rs
+++ b/crates/motiongfx/docs/world.rs
@@ -24,7 +24,6 @@ pub fn timeline() -> (Registry, Timeline<World>) {
         .with_interp(|a: &f32, b: &f32, t| a + (b - a) * t)
         .play(s(1))
         .compile();
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     (registry, timeline)
 }

--- a/crates/motiongfx/examples/custom_world.rs
+++ b/crates/motiongfx/examples/custom_world.rs
@@ -89,8 +89,7 @@ fn main() {
     .ord_chain();
 
     // Compile into a timeline.
-    builder.add_tracks(track.compile());
-    let mut timeline = builder.compile();
+    let mut timeline = builder.compile(track.compile());
 
     // Bake actions into segments.
     timeline.bake_actions(&world.registry, &world.subject_world);

--- a/crates/motiongfx/src/action/id_registry.rs
+++ b/crates/motiongfx/src/action/id_registry.rs
@@ -113,8 +113,8 @@ pub(crate) type Cleanup = fn(&mut Resources, UId);
 /// the whole [`ActionTable`](crate::action::ActionTable), keyed by
 /// `I`'s [`TypeId`]. Stored as a [`Resources`] entry itself, right
 /// alongside each `I`'s [`IdRegistry`], rather than duplicated once
-/// per action — the function is identical for every action sharing
-/// the same `I`.
+/// per action, since the function is identical for every action
+/// sharing the same `I`.
 pub(crate) type CleanupRegistry = HashMap<TypeId, Cleanup>;
 
 pub(crate) fn cleanup_fn<I: SubjectId>(

--- a/crates/motiongfx/src/lib.rs
+++ b/crates/motiongfx/src/lib.rs
@@ -14,9 +14,9 @@ pub mod timeline;
 pub mod track;
 pub mod world;
 
-// Re-exports field_path as it is essential for motiongfx to work!
 pub use field_path;
 pub use motiongfx_interp;
+pub use nonempty;
 
 pub mod prelude {
     pub use field_path::field_accessor::FieldAccessor;
@@ -28,6 +28,7 @@ pub mod prelude {
         Action, ActionBuilder, ActionId, InterpActionBuilder,
         InterpFn,
     };
+    pub use crate::nonempty::{self, nonempty};
     pub use crate::path;
     pub use crate::pipeline::PipelineKey;
     pub use crate::registry::{
@@ -35,7 +36,9 @@ pub mod prelude {
     };
     pub use crate::time::{cs, ms, ns, s};
     pub use crate::timeline::{Timeline, TimelineBuilder};
-    pub use crate::track::{Track, TrackFragment, TrackOrdering};
+    pub use crate::track::{
+        Track, TrackFragment, TrackList, TrackOrdering,
+    };
     pub use crate::world::SubjectSource;
 }
 

--- a/crates/motiongfx/src/resources.rs
+++ b/crates/motiongfx/src/resources.rs
@@ -3,8 +3,7 @@ use core::any::{Any, TypeId};
 
 use hashbrown::HashMap;
 
-/// A type-keyed singleton map, playing the role of a `bevy_ecs`
-/// `Resource` store without depending on `bevy_ecs`.
+/// A type-keyed singleton map.
 #[derive(Default)]
 pub(crate) struct Resources {
     map: HashMap<TypeId, Box<dyn Any + Send + Sync>>,

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -16,7 +16,7 @@ use crate::action::{
 use crate::pipeline::{BakeCtx, PipelineKey, Range, SampleCtx};
 use crate::registry::Registry;
 use crate::subject::SubjectId;
-use crate::track::Track;
+use crate::track::{Track, TrackList};
 use crate::world::SubjectSource;
 
 pub struct Timeline<W> {
@@ -445,7 +445,6 @@ pub struct TimelineBuilder<'a, W> {
     registry: &'a mut Registry,
     action_table: ActionTable,
     pipeline_counts: HashMap<PipelineKey, u32>,
-    tracks: Vec<Track>,
     _marker: PhantomData<fn() -> W>,
 }
 
@@ -456,7 +455,6 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
             registry,
             action_table: ActionTable::new(),
             pipeline_counts: HashMap::new(),
-            tracks: Vec::new(),
             _marker: PhantomData,
         }
     }
@@ -559,35 +557,18 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
         false
     }
 
-    /// Add [`Track`]\(s\) to the timeline.
-    pub fn add_tracks(
-        &mut self,
-        tracks: impl IntoIterator<Item = Track>,
-    ) {
-        self.tracks.extend(tracks);
-    }
-
     /// Compile into a [`Timeline`].
-    ///
-    /// ## Panic
-    ///
-    /// Panics if the track is empty.
-    /// Use [`Self::try_compile`] to explicitly handle the case where
-    /// the track may be empty.
-    pub fn compile(self) -> Timeline<W> {
-        // TODO(nixon): What happens when track is empty?
-        debug_assert!(
-            !self.tracks.is_empty(),
-            "Track cannot be empty!"
-        );
-
+    pub fn compile(
+        self,
+        tracks: impl Into<TrackList>,
+    ) -> Timeline<W> {
         Timeline {
             action_table: self.action_table,
             pipeline_counts: self
                 .pipeline_counts
                 .into_iter()
                 .collect(),
-            tracks: self.tracks.into_boxed_slice(),
+            tracks: tracks.into().into_boxed_slice(),
             queue_cache: QueueCache::new(),
             sample_queue: HashMap::new(),
             curr_time: Duration::ZERO,
@@ -596,12 +577,6 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
             target_index: 0,
             _marker: PhantomData,
         }
-    }
-
-    /// Similar to [`Self::compile`] but return `None` instead of
-    /// panicking.
-    pub fn try_compile(self) -> Option<Timeline<W>> {
-        (!self.tracks.is_empty()).then(|| self.compile())
     }
 }
 

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use field_path::field::UntypedField;
 use hashbrown::HashMap;
+use nonempty::NonEmpty;
 
 use crate::action::{ActionClip, ActionKey};
 use crate::sequence::Sequence;
@@ -168,6 +169,16 @@ impl TrackFragment {
         }
     }
 
+    /// A fragment with no clips of its own, reserving `duration` of
+    /// time - for a slot in the tree nothing resolves into an action
+    /// yet.
+    pub fn silent(duration: Duration) -> Self {
+        Self {
+            sequences: HashMap::new(),
+            duration,
+        }
+    }
+
     /// Updates or inserts a [`Sequence`] in a track.
     ///
     /// If the [`ActionKey`] already exists, this method appends the
@@ -294,7 +305,7 @@ impl Default for TrackFragment {
 /// A `Track` is created from a [`TrackFragment`] and provides an
 /// immutable, space-efficient layout. [`ActionClip`]s are stored
 /// in a flat array with spans for quick access.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Track {
     // TODO: Use this to optimized baking/sampling? (There are no
     // use case for the lookups atm!)
@@ -365,6 +376,41 @@ impl IntoIterator for Track {
 
     fn into_iter(self) -> Self::IntoIter {
         [self].into_iter()
+    }
+}
+
+/// The [`Track`]s a [`Timeline`](crate::timeline::Timeline) plays
+/// through, always at least one.
+#[derive(Clone, Debug)]
+pub struct TrackList(pub NonEmpty<Track>);
+
+impl From<Track> for TrackList {
+    fn from(track: Track) -> Self {
+        Self::new(track)
+    }
+}
+
+impl TrackList {
+    pub fn new(track: Track) -> Self {
+        Self(NonEmpty::new(track))
+    }
+
+    pub fn collect(
+        tracks: impl IntoIterator<Item = Track>,
+    ) -> Option<Self> {
+        NonEmpty::collect(tracks).map(Self)
+    }
+
+    pub fn add(
+        &mut self,
+        tracks: impl IntoIterator<Item = Track>,
+    ) -> &mut Self {
+        self.0.extend(tracks);
+        self
+    }
+
+    pub fn into_boxed_slice(self) -> Box<[Track]> {
+        self.0.into_iter().collect()
     }
 }
 

--- a/crates/motiongfx_scene/README.md
+++ b/crates/motiongfx_scene/README.md
@@ -22,8 +22,9 @@ Pure data, no engine and no backend. A `Scene<B>` is three parts:
 - **`stage`**: The value every animated field starts from. One
   `FieldSeed` (a `FieldRef` plus a value id) per subject field.
 - **`animation`**: A tree of `Block`s. Each block has a `Combinator`
-  (`Chain`, `All`, `Any`, `Flow`) and children that are nested blocks
-  or leaf `Node::action(ActionCmd)`s. A `Node` can carry a `delay`.
+  (`Chain`, `All`, `Flow`) and children that are nested blocks, leaf
+  `Node::action(ActionCmd)`s, or `Node::draft` timing slots. A `Node`
+  can carry a `delay`.
 - **`values`**: The `ValuePool`. Every number an action or seed refers
   to, addressed by id so the tree itself stays plain data.
 
@@ -53,6 +54,7 @@ let scene: Scene<Toy> = Scene {
         duration: ms(200),
         ease: None,
         interp: None,
+        name: None,
     })]),
     values,
 };

--- a/crates/motiongfx_scene/docs/backend.rs
+++ b/crates/motiongfx_scene/docs/backend.rs
@@ -129,6 +129,7 @@ pub fn scene() -> Scene<Toy> {
             duration: ms(200),
             ease: None,
             interp: None,
+            name: None,
         })]),
         values,
     }

--- a/crates/motiongfx_scene/examples/dummy_scene.rs
+++ b/crates/motiongfx_scene/examples/dummy_scene.rs
@@ -44,6 +44,7 @@ fn main() {
                 duration: ms(600),
                 ease: Some(Ease::CubicEaseInOut),
                 interp: None,
+                name: None,
             }),
             Node::action(ActionCmd {
                 subject: 0,
@@ -53,6 +54,7 @@ fn main() {
                 duration: Duration::ZERO,
                 ease: None,
                 interp: None,
+                name: None,
             }),
         ]),
         values,

--- a/crates/motiongfx_scene/src/block.rs
+++ b/crates/motiongfx_scene/src/block.rs
@@ -1,9 +1,10 @@
 //! The animation tree: nested [`Block`]s of [`Node`]s.
 //!
 //! A [`Block`] carries a [`Combinator`] for how its children combine;
-//! a [`Node`] is a nested block, an action leaf, or a delayed wrapper.
-//! Each maps 1:1 onto a `motiongfx` track combinator.
+//! a [`Node`] is a nested block, an action leaf, or an unassigned
+//! draft, each with its own delay.
 
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::time::Duration;
 
@@ -24,6 +25,8 @@ use crate::refs::FieldRef;
 pub struct Block<B: SceneBackend> {
     pub combinator: Combinator,
     pub children: Vec<Node<B>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 impl<B: SceneBackend> Block<B> {
@@ -32,6 +35,7 @@ impl<B: SceneBackend> Block<B> {
         Self {
             combinator: Combinator::Chain,
             children,
+            name: None,
         }
     }
 }
@@ -44,8 +48,6 @@ pub enum Combinator {
     Chain,
     /// Simultaneous; children share a start, wait for all. (`ord_all`)
     All,
-    /// Simultaneous; wait for any. (`ord_any`)
-    Any,
     /// Staggered starts, one `delay` apart. (`ord_flow`)
     Flow(Duration),
 }
@@ -70,6 +72,15 @@ pub enum Node<B: SceneBackend> {
         delay: Option<Duration>,
         action: ActionCmd<B>,
     },
+    /// Not yet a real action: reserves a timing slot without a
+    /// subject or field picked yet.
+    Draft {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        delay: Option<Duration>,
+        duration: Duration,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
 }
 
 impl<B: SceneBackend> Node<B> {
@@ -86,12 +97,22 @@ impl<B: SceneBackend> Node<B> {
         }
     }
 
+    /// An unassigned slot of `duration`, starting with its parent.
+    pub fn draft(duration: Duration) -> Self {
+        Self::Draft {
+            delay: None,
+            duration,
+            name: None,
+        }
+    }
+
     /// Offsets this node's start by `offset`, replacing any existing
     /// delay.
     pub fn delay(mut self, offset: Duration) -> Self {
         *match &mut self {
             Self::Block { delay, .. }
-            | Self::Action { delay, .. } => delay,
+            | Self::Action { delay, .. }
+            | Self::Draft { delay, .. } => delay,
         } = Some(offset);
         self
     }
@@ -115,4 +136,6 @@ pub struct ActionCmd<B: SceneBackend> {
     /// `None` = the field type's default interpolation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interp: Option<B::InterpId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }

--- a/crates/motiongfx_scene/src/compile.rs
+++ b/crates/motiongfx_scene/src/compile.rs
@@ -37,9 +37,8 @@ impl<B: SceneBackend> Scene<B> {
         )?;
 
         let track = root_fragment.compile();
-        builder.add_tracks([track]);
 
-        builder.try_compile().ok_or(CompileError::EmptyTimeline)
+        Ok(builder.compile(track))
     }
 
     /// Writes the [`Stage`](crate::scene::Stage)'s initial values into
@@ -80,6 +79,9 @@ fn walk_node<B: SceneBackend>(
             delay,
             resolve_action(action, registry, values, builder)?,
         ),
+        Node::Draft {
+            delay, duration, ..
+        } => (delay, TrackFragment::silent(*duration)),
     };
 
     Ok(match offset {
@@ -105,7 +107,6 @@ fn walk_block<B: SceneBackend>(
     let result = match block.combinator {
         Combinator::Chain => fragments.ord_chain(),
         Combinator::All => fragments.ord_all(),
-        Combinator::Any => fragments.ord_any(),
         Combinator::Flow(delay) => fragments.ord_flow(delay),
     };
 

--- a/crates/motiongfx_scene/src/error.rs
+++ b/crates/motiongfx_scene/src/error.rs
@@ -50,9 +50,6 @@ pub enum CompileError<B: SceneBackend> {
         type_name: &'static str,
         field: FieldRef,
     },
-
-    /// The builder produced no tracks, so there is nothing to play.
-    EmptyTimeline,
 }
 
 // Manual Display to keep the crate `no_std` + `alloc`.
@@ -97,9 +94,6 @@ impl<B: SceneBackend> fmt::Display for CompileError<B> {
                     field.type_name(),
                     field.path()
                 )
-            }
-            Self::EmptyTimeline => {
-                write!(f, "scene compiled to an empty timeline")
             }
         }
     }

--- a/crates/motiongfx_scene/tests/roundtrip.rs
+++ b/crates/motiongfx_scene/tests/roundtrip.rs
@@ -68,6 +68,7 @@ fn sample() -> Scene<RoundtripBackend> {
         duration: ms(500),
         ease: Some(Ease::CubicEaseInOut),
         interp: None,
+        name: None,
     };
 
     let animation = Block::chain(vec![
@@ -77,6 +78,7 @@ fn sample() -> Scene<RoundtripBackend> {
                 Node::action(action(1.0)),
                 Node::action(action(0.5)),
             ],
+            name: None,
         }),
         Node::action(action(2.0)).delay(ms(200)),
     ]);

--- a/crates/motiongfx_scene/tests/toy.rs
+++ b/crates/motiongfx_scene/tests/toy.rs
@@ -119,6 +119,7 @@ fn action_cmd(
         duration: ms(duration_ms),
         ease: None,
         interp: None,
+        name: None,
     }
 }
 
@@ -322,6 +323,7 @@ fn all_combinator_runs_children_simultaneously() {
                     200,
                 )),
             ],
+            name: None,
         },
         values,
     };
@@ -403,6 +405,7 @@ fn one_op_registration_covers_every_owning_type_sharing_t() {
         duration: ms(100),
         ease: None,
         interp: None,
+        name: None,
     };
     // Two owning types on one subject, so two initial entries.
     let mut staged = subject(&mut values, 0, &["x"]);

--- a/examples/bevy_examples/examples/custom_ease.rs
+++ b/examples/bevy_examples/examples/custom_ease.rs
@@ -43,9 +43,7 @@ fn spawn_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/custom_interp.rs
+++ b/examples/bevy_examples/examples/custom_interp.rs
@@ -45,9 +45,7 @@ fn spawn_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/easings.rs
+++ b/examples/bevy_examples/examples/easings.rs
@@ -98,9 +98,9 @@ fn spawn_timeline(
         })
         .ord_chain();
 
-    b.add_tracks(track.compile());
+    let tracks = track.compile();
 
-    let timeline = b.compile();
+    let timeline = b.compile(tracks);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/bevy_examples/examples/hello_world.rs
+++ b/examples/bevy_examples/examples/hello_world.rs
@@ -93,8 +93,7 @@ fn spawn_timeline(
     }
 
     let track = cube_tracks.ord_flow(cs(1)).compile();
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     commands.spawn((
         motiongfx.add_timeline(timeline),

--- a/examples/bevy_examples/examples/minimal.rs
+++ b/examples/bevy_examples/examples/minimal.rs
@@ -65,8 +65,7 @@ fn build_timeline(
     .ord_all()
     .compile();
 
-    b.add_tracks(track);
-    let timeline = b.compile();
+    let timeline = b.compile(track);
 
     // Spawns the timeline and start playing.
     commands.spawn((

--- a/examples/bevy_examples/examples/recording.rs
+++ b/examples/bevy_examples/examples/recording.rs
@@ -115,9 +115,7 @@ fn spawn_timeline(
         .play(s(1))
         .compile();
 
-    b.add_tracks(track);
-
-    let timeline = b.compile();
+    let timeline = b.compile(track);
     commands.spawn((
         motiongfx.add_timeline(timeline),
         FixedRatePlayer::new(144),

--- a/examples/bevy_examples/examples/slide_basic.rs
+++ b/examples/bevy_examples/examples/slide_basic.rs
@@ -83,9 +83,7 @@ fn spawn_timeline(
     .ord_flow(cs(10))
     .compile();
 
-    b.add_tracks([slide0, slide1]);
-
-    let timeline = b.compile();
+    let timeline = b.compile(TrackList(nonempty![slide0, slide1]));
     commands.spawn((
         motiongfx.add_timeline(timeline),
         RealtimePlayer::new().with_playing(true),

--- a/examples/vello_winit_example/examples/lissajous.rs
+++ b/examples/vello_winit_example/examples/lissajous.rs
@@ -185,7 +185,6 @@ impl LissajousTableDemo {
         }
         let grid_track =
             pair_tracks.into_iter().ord_flow(cs(5)).compile();
-        b.add_tracks(grid_track);
 
         // Track 1: curves draw in and out, looped by the caller.
         let max_diag = N_X + N_Y;
@@ -223,9 +222,8 @@ impl LissajousTableDemo {
             })
             .ord_flow(STAGGER)
             .compile();
-        b.add_tracks(curve_track);
-
-        let mut timeline = b.compile();
+        let mut timeline =
+            b.compile(TrackList(nonempty![grid_track, curve_track]));
         timeline.bake_actions(&registry, &world);
         let grid_duration = timeline.tracks()[0].duration();
         let curve_duration = timeline.tracks()[1].duration();


### PR DESCRIPTION
From moxie: TrackList + TimelineBuilder::compile(track) (#125), TrackFragment::silent + Node::Draft (#154), drop Combinator::Any and CompileError::EmptyTimeline (#153), Reflect on the Bevy backend enums, name fields on Block/ActionCmd. Examples migrated off add_tracks.

Also drop the Version Matrix from the motiongfx README (it does not depend on Bevy).