### PR TITLE
Fix action overlapping & alias shadowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "criterion",
  "field_path",
  "hashbrown 0.17.1",
+ "indexmap",
  "motiongfx_interp",
  "nonempty",
  "tracing",

--- a/crates/bevy_motiongfx/Cargo.toml
+++ b/crates/bevy_motiongfx/Cargo.toml
@@ -54,6 +54,10 @@ tracing = [
     "motiongfx/tracing",
     "motiongfx_scene?/tracing",
 ]
+diagnostics = [
+    "motiongfx/diagnostics",
+    "motiongfx_scene?/diagnostics",
+]
 asset = ["dep:bevy_asset"]
 transform = ["dep:bevy_transform"]
 color = ["dep:bevy_color"]

--- a/crates/bevy_motiongfx/Cargo.toml
+++ b/crates/bevy_motiongfx/Cargo.toml
@@ -40,7 +40,7 @@ bevy = { workspace = true, features = ["bevy_pbr"] }
 workspace = true
 
 [features]
-default = ["std", "asset", "transform", "color"]
+default = ["std", "tracing", "asset", "transform", "color"]
 std = [
     "motiongfx/std",
     "motiongfx_scene?/std",
@@ -49,15 +49,20 @@ std = [
     "bevy_platform/std",
     "bevy_time/std",
 ]
+tracing = [
+    "dep:tracing",
+    "motiongfx/tracing",
+    "motiongfx_scene?/tracing",
+]
 asset = ["dep:bevy_asset"]
 transform = ["dep:bevy_transform"]
 color = ["dep:bevy_color"]
 scene = [
     "dep:motiongfx_scene",
     "dep:indexmap",
-    "dep:tracing",
     "dep:ron",
     "dep:bevy_reflect",
+    "tracing",
     "bevy_math/serialize",
     "bevy_transform/bevy_reflect",
     "asset",

--- a/crates/bevy_motiongfx/src/scene/backend.rs
+++ b/crates/bevy_motiongfx/src/scene/backend.rs
@@ -104,7 +104,7 @@ pub trait SceneRegistryExt {
         field_acc: FieldAccessor<S, T>,
     ) -> &mut Self
     where
-        S: TypePath,
+        S: TypePath + Clone + ThreadSafe,
         BevyWorld: SubjectSource<EntityUid, S>,
         ValuePool: ValueColumn<Uuid, T>,
         T: ThreadSafe + Clone;
@@ -129,7 +129,7 @@ pub trait SceneRegistryExt {
         field_acc: FieldAccessor<S, T>,
     ) -> &mut Self
     where
-        S: TypePath,
+        S: TypePath + Clone + ThreadSafe,
         BevyWorld: SubjectSource<EntityUid, S>,
         ValuePool: ValueColumn<Uuid, T>,
         T: Interpolation<M> + ThreadSafe + Clone,
@@ -146,7 +146,7 @@ impl SceneRegistryExt for BackendRegistry {
         field_acc: FieldAccessor<S, T>,
     ) -> &mut Self
     where
-        S: TypePath,
+        S: TypePath + Clone + ThreadSafe,
         BevyWorld: SubjectSource<EntityUid, S>,
         ValuePool: ValueColumn<Uuid, T>,
         T: ThreadSafe + Clone,

--- a/crates/motiongfx/Cargo.toml
+++ b/crates/motiongfx/Cargo.toml
@@ -32,3 +32,5 @@ workspace = true
 default = ["std", "tracing"]
 std = ["motiongfx_interp/std"]
 tracing = ["dep:tracing"]
+# Records dropped clips on the compiled `Track` for editor tooling.
+diagnostics = []

--- a/crates/motiongfx/Cargo.toml
+++ b/crates/motiongfx/Cargo.toml
@@ -16,6 +16,7 @@ field_path = { workspace = true }
 typarena = { workspace = true }
 nonempty = { workspace = true }
 hashbrown = { workspace = true, features = ["default-hasher"] }
+indexmap = { workspace = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/motiongfx/src/action.rs
+++ b/crates/motiongfx/src/action.rs
@@ -72,9 +72,8 @@ pub struct ActionKey {
     field: UntypedField,
 }
 
-/// Whether two field paths reach overlapping memory: one is a
-/// segment-prefix of the other. The source itself (`""`) is a prefix
-/// of every path.
+/// Two field paths alias in memory when one is a segment-prefix of
+/// the other. The source itself (`""`) prefixes every path.
 pub(crate) fn paths_alias(a: &str, b: &str) -> bool {
     let (short, long) =
         if a.len() <= b.len() { (a, b) } else { (b, a) };

--- a/crates/motiongfx/src/action.rs
+++ b/crates/motiongfx/src/action.rs
@@ -72,6 +72,16 @@ pub struct ActionKey {
     field: UntypedField,
 }
 
+/// Whether two field paths reach overlapping memory: one is a
+/// segment-prefix of the other. The source itself (`""`) is a prefix
+/// of every path.
+pub(crate) fn paths_alias(a: &str, b: &str) -> bool {
+    let (short, long) =
+        if a.len() <= b.len() { (a, b) } else { (b, a) };
+    long.strip_prefix(short)
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with("::"))
+}
+
 impl ActionKey {
     pub fn new(
         subject_id: UntypedSubjectId,

--- a/crates/motiongfx/src/action/id_registry.rs
+++ b/crates/motiongfx/src/action/id_registry.rs
@@ -51,8 +51,10 @@ impl<I: SubjectId> IdRegistry<I> {
             self.next_uid
         });
 
-        // SAFETY: `uid_counts` is added for every new UId!
-        *self.instance_counts.get_mut(&uid).unwrap() += 1;
+        *self
+            .instance_counts
+            .get_mut(&uid)
+            .expect("above logic made sure this slot exists") += 1;
 
         uid
     }
@@ -72,7 +74,10 @@ impl<I: SubjectId> IdRegistry<I> {
 
         // Remove the underlying data when it's the last instance.
         if *count == 0 {
-            let id = self.id_map.get(uid).unwrap();
+            let id = self
+                .id_map
+                .get(uid)
+                .expect("above check made sure this slot exists");
             self.uid_map.remove(id);
             self.id_map.remove(uid);
             self.instance_counts.remove(uid);

--- a/crates/motiongfx/src/action/table.rs
+++ b/crates/motiongfx/src/action/table.rs
@@ -143,24 +143,6 @@ impl ActionTable {
         self.table.ensure_column::<Segment<T>>()
     }
 
-    /// The [`ActionStorage<T>`] column, if any `T` action exists.
-    pub(crate) fn action_column<T: ThreadSafe>(
-        &self,
-    ) -> Option<ColumnId> {
-        self.table.type_column::<ActionStorage<T>>()
-    }
-
-    /// Read an action through a cached [`ActionStorage`] column.
-    pub(crate) fn get_action_by_column<T: ThreadSafe>(
-        &self,
-        col: ColumnId,
-        id: &ActionId,
-    ) -> Option<&impl Action<T>> {
-        self.table
-            .get_by_column::<ActionStorage<T>>(col, id)
-            .map(|a| &a.action)
-    }
-
     /// Write a segment through a cached [`Segment`] column.
     pub(crate) fn set_segment_by_column<T: ThreadSafe>(
         &mut self,

--- a/crates/motiongfx/src/pipeline.rs
+++ b/crates/motiongfx/src/pipeline.rs
@@ -6,15 +6,17 @@ use core::any::TypeId;
 use core::marker::PhantomData;
 use core::time::Duration;
 
-use bake::{BakeCtx, bake};
-use func_pointers::{BakeFnPtr, SampleFnPtr};
+use bake::{BakeClipCtx, bake_clip};
+use func_pointers::{BakeClipFnPtr, SampleFnPtr};
 use sample::{SampleCtx, sample};
 
 use crate::ThreadSafe;
 use crate::action::ActionKey;
-use crate::pipeline::func_pointers::{BakeFn, SampleFn};
+use crate::pipeline::func_pointers::{BakeClipFn, SampleFn};
 use crate::subject::SubjectId;
 use crate::world::SubjectSource;
+
+pub use bake::BakeScratch;
 
 pub struct PipelineHandle<W, I, S, T> {
     #[expect(clippy::type_complexity)]
@@ -105,7 +107,7 @@ impl PipelineKey {
 /// The world type `W` is erased at storage; it must match at call sites.
 #[derive(Debug, Clone, Copy)]
 pub struct Pipeline<W, I, S, T> {
-    bake: BakeFn<W>,
+    bake_clip: BakeClipFn<W>,
     sample: SampleFn<W>,
     #[expect(clippy::type_complexity)]
     _marker: PhantomData<fn() -> (I, S, T)>,
@@ -116,11 +118,11 @@ impl<W, I, S, T> Pipeline<W, I, S, T> {
     where
         W: SubjectSource<I, S>,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: Clone + ThreadSafe,
     {
         Self {
-            bake: bake::<W, I, S, T>,
+            bake_clip: bake_clip::<W, I, S, T>,
             sample: sample::<W, I, S, T>,
             _marker: PhantomData,
         }
@@ -128,7 +130,7 @@ impl<W, I, S, T> Pipeline<W, I, S, T> {
 
     pub fn untyped(&self) -> PipelineUntyped {
         PipelineUntyped {
-            bake: BakeFnPtr::new(self.bake),
+            bake_clip: BakeClipFnPtr::new(self.bake_clip),
             sample: SampleFnPtr::new(self.sample),
         }
     }
@@ -138,7 +140,7 @@ impl<W, I, S, T> Default for Pipeline<W, I, S, T>
 where
     W: SubjectSource<I, S>,
     I: SubjectId,
-    S: 'static,
+    S: Clone + ThreadSafe,
     T: Clone + ThreadSafe,
 {
     fn default() -> Self {
@@ -148,7 +150,7 @@ where
 
 #[derive(Debug, Clone, Copy)]
 pub struct PipelineUntyped {
-    bake: BakeFnPtr,
+    bake_clip: BakeClipFnPtr,
     sample: SampleFnPtr,
 }
 
@@ -156,8 +158,8 @@ impl PipelineUntyped {
     /// # Safety
     ///
     /// `W` must match the type used when registering this pipeline.
-    pub(crate) unsafe fn bake<W>(&self, ctx: BakeCtx<W>) {
-        let f = unsafe { self.bake.typed_unchecked::<W>() };
+    pub(crate) unsafe fn bake_clip<W>(&self, ctx: BakeClipCtx<W>) {
+        let f = unsafe { self.bake_clip.typed_unchecked::<W>() };
         f(ctx)
     }
 

--- a/crates/motiongfx/src/pipeline.rs
+++ b/crates/motiongfx/src/pipeline.rs
@@ -4,7 +4,6 @@ pub mod sample;
 
 use core::any::TypeId;
 use core::marker::PhantomData;
-use core::time::Duration;
 
 use bake::{BakeClipCtx, bake_clip};
 use func_pointers::{BakeClipFnPtr, SampleFnPtr};
@@ -172,93 +171,4 @@ impl PipelineUntyped {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
-pub struct Range {
-    pub start: Duration,
-    pub end: Duration,
-}
-
-impl Range {
-    /// Calculate if 2 [`Range`]s overlap.
-    pub fn overlap(&self, other: &Self) -> bool {
-        self.start <= other.end && other.start <= self.end
-    }
-
-    /// The span shared by both [`Range`]s, or `None` when they share
-    /// no span of positive length. A boundary-only touch is `None`.
-    pub fn intersect(&self, other: &Self) -> Option<Self> {
-        let start = self.start.max(other.start);
-        let end = self.end.min(other.end);
-        (start < end).then_some(Self { start, end })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::time::s;
-
-    use super::*;
-
-    #[test]
-    fn range_overlap_behavior() {
-        let a = Range {
-            start: s(0),
-            end: s(5),
-        };
-        let b = Range {
-            start: s(3),
-            end: s(8),
-        };
-        let c = Range {
-            start: s(6),
-            end: s(10),
-        };
-        let d = Range {
-            start: s(5),
-            end: s(5),
-        }; // touching boundary
-
-        assert!(
-            a.overlap(&b),
-            "Overlapping ranges should return true"
-        );
-        assert!(
-            !a.overlap(&c),
-            "Separated ranges should return false"
-        );
-        assert!(
-            a.overlap(&d),
-            "Touching at end should count as overlap"
-        );
-    }
-
-    #[test]
-    fn range_intersect_returns_shared_span() {
-        let a = Range {
-            start: s(0),
-            end: s(5),
-        };
-        let b = Range {
-            start: s(3),
-            end: s(8),
-        };
-        let c = Range {
-            start: s(6),
-            end: s(10),
-        };
-        let d = Range {
-            start: s(5),
-            end: s(8),
-        }; // touches `a` at the boundary only
-
-        assert_eq!(
-            a.intersect(&b),
-            Some(Range {
-                start: s(3),
-                end: s(5),
-            }),
-        );
-        assert_eq!(a.intersect(&c), None);
-        assert_eq!(a.intersect(&d), None);
-    }
-}
+pub use crate::time::Range;

--- a/crates/motiongfx/src/pipeline.rs
+++ b/crates/motiongfx/src/pipeline.rs
@@ -181,6 +181,14 @@ impl Range {
     pub fn overlap(&self, other: &Self) -> bool {
         self.start <= other.end && other.start <= self.end
     }
+
+    /// The span shared by both [`Range`]s, or `None` when they share
+    /// no span of positive length. A boundary-only touch is `None`.
+    pub fn intersect(&self, other: &Self) -> Option<Self> {
+        let start = self.start.max(other.start);
+        let end = self.end.min(other.end);
+        (start < end).then_some(Self { start, end })
+    }
 }
 
 #[cfg(test)]
@@ -220,5 +228,35 @@ mod tests {
             a.overlap(&d),
             "Touching at end should count as overlap"
         );
+    }
+
+    #[test]
+    fn range_intersect_returns_shared_span() {
+        let a = Range {
+            start: s(0),
+            end: s(5),
+        };
+        let b = Range {
+            start: s(3),
+            end: s(8),
+        };
+        let c = Range {
+            start: s(6),
+            end: s(10),
+        };
+        let d = Range {
+            start: s(5),
+            end: s(8),
+        }; // touches `a` at the boundary only
+
+        assert_eq!(
+            a.intersect(&b),
+            Some(Range {
+                start: s(3),
+                end: s(5),
+            }),
+        );
+        assert_eq!(a.intersect(&c), None);
+        assert_eq!(a.intersect(&d), None);
     }
 }

--- a/crates/motiongfx/src/pipeline.rs
+++ b/crates/motiongfx/src/pipeline.rs
@@ -1,20 +1,19 @@
-pub mod func_pointers;
+pub mod bake;
+mod func_pointers;
+pub mod sample;
 
 use core::any::TypeId;
 use core::marker::PhantomData;
 use core::time::Duration;
 
+use bake::{BakeCtx, bake};
 use func_pointers::{BakeFnPtr, SampleFnPtr};
+use sample::{SampleCtx, sample};
 
 use crate::ThreadSafe;
-use crate::action::{
-    ActionClip, ActionId, ActionKey, ActionTable, InterpStorage,
-    SampleMode, Segment,
-};
+use crate::action::ActionKey;
 use crate::pipeline::func_pointers::{BakeFn, SampleFn};
-use crate::registry::AccessorRegistry;
 use crate::subject::SubjectId;
-use crate::track::Track;
 use crate::world::SubjectSource;
 
 pub struct PipelineHandle<W, I, S, T> {
@@ -171,141 +170,6 @@ impl PipelineUntyped {
     }
 }
 
-pub struct BakeCtx<'a, W> {
-    pub world: &'a W,
-    pub track: &'a Track,
-    pub action_table: &'a mut ActionTable,
-    pub accessor_registry: &'a AccessorRegistry,
-}
-
-pub fn bake<W, I, S, T>(ctx: BakeCtx<W>)
-where
-    W: SubjectSource<I, S>,
-    I: SubjectId,
-    S: 'static,
-    T: Clone + ThreadSafe,
-{
-    // Resolve the per-`T` columns once so the clip loop doesn't
-    // re-hash the `TypeId` on every access. No `T` action, no bake.
-    let Some(action_col) = ctx.action_table.action_column::<T>()
-    else {
-        return;
-    };
-    let segment_col = ctx.action_table.ensure_segment_column::<T>();
-
-    for (key, span) in ctx.track.sequences_spans() {
-        let Some(accessor) =
-            ctx.accessor_registry.get::<S, T>(key.field())
-        else {
-            continue;
-        };
-
-        let Some(&id) =
-            ctx.action_table.get_id(&key.subject_id().uid())
-        else {
-            continue;
-        };
-
-        let Some(source) = ctx.world.get_source(id) else {
-            continue;
-        };
-
-        let mut start = accessor.get_ref(source).clone();
-
-        for ActionClip { id, .. } in ctx.track.clips(*span) {
-            let Some(action) = ctx
-                .action_table
-                .get_action_by_column::<T>(action_col, id)
-            else {
-                continue;
-            };
-
-            let end = action(&start);
-            let segment = Segment::new(start.clone(), end.clone());
-
-            ctx.action_table.set_segment_by_column(
-                *id,
-                segment,
-                segment_col,
-            );
-
-            start = end;
-        }
-    }
-}
-
-pub struct SampleCtx<'a, W> {
-    pub world: &'a mut W,
-    pub action_table: &'a ActionTable,
-    pub accessor_registry: &'a AccessorRegistry,
-    /// The queued actions for this pipeline, each with its
-    /// [`SampleMode`] resolved at queue time.
-    pub samples: &'a [(ActionId, SampleMode)],
-}
-
-pub fn sample<W, I, S, T>(ctx: SampleCtx<W>)
-where
-    W: SubjectSource<I, S>,
-    I: SubjectId,
-    S: 'static,
-    T: Clone + ThreadSafe,
-{
-    let table = ctx.action_table.table();
-    let Some(segment_col) = table.type_column::<Segment<T>>() else {
-        return;
-    };
-    let Some(interp_col) = table.type_column::<InterpStorage<T>>()
-    else {
-        return;
-    };
-
-    for &(id, sample_mode) in ctx.samples {
-        let Some(segment) =
-            table.get_by_column::<Segment<T>>(segment_col, &id)
-        else {
-            continue;
-        };
-        let Some(interp) =
-            table.get_by_column::<InterpStorage<T>>(interp_col, &id)
-        else {
-            continue;
-        };
-
-        let Some(key) = ctx.action_table.key(&id) else {
-            continue;
-        };
-        let ease = ctx.action_table.ease(&id);
-        let Some(accessor) =
-            ctx.accessor_registry.get::<S, T>(key.field())
-        else {
-            continue;
-        };
-
-        let Some(&sid) =
-            ctx.action_table.get_id(&key.subject_id().uid())
-        else {
-            continue;
-        };
-
-        let target = match sample_mode {
-            SampleMode::Start => segment.start.clone(),
-            SampleMode::End => segment.end.clone(),
-            SampleMode::Interp(t) => {
-                let t = match ease {
-                    Some(ease) => ease.0(t),
-                    None => t,
-                };
-
-                interp.0(&segment.start, &segment.end, t)
-            }
-        };
-
-        ctx.world.apply_source(sid, |source| {
-            *accessor.get_mut(source) = target;
-        });
-    }
-}
-
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Range {
     pub start: Duration,
@@ -322,124 +186,8 @@ impl Range {
 #[cfg(test)]
 mod tests {
     use crate::time::s;
-    use motiongfx_interp::interpolation::Interpolation;
 
     use super::*;
-
-    struct MockWorld(f32);
-
-    impl SubjectSource<u32, f32> for MockWorld {
-        fn get_source(&self, _id: u32) -> Option<&f32> {
-            Some(&self.0)
-        }
-
-        fn apply_source<R>(
-            &mut self,
-            _id: u32,
-            f: impl FnOnce(&mut f32) -> R,
-        ) -> Option<R> {
-            Some(f(&mut self.0))
-        }
-    }
-
-    fn sample_mock(
-        action_table: &ActionTable,
-        accessor_registry: &AccessorRegistry,
-        world: &mut MockWorld,
-        samples: &[(ActionId, SampleMode)],
-    ) {
-        sample::<MockWorld, u32, f32, f32>(SampleCtx {
-            world,
-            action_table,
-            accessor_registry,
-            samples,
-        });
-    }
-
-    /// Exercises the multi-column probe in `sample`: `ActionKey`,
-    /// `Segment<T>` and `InterpStorage<T>` are read per queued action,
-    /// with the `SampleMode` supplied by the queue.
-    #[test]
-    fn sample_join_reads_all_required_columns() {
-        let field_acc = crate::path!(<f32>);
-        let field = field_acc.field.untyped();
-
-        let mut accessor_registry = AccessorRegistry::new();
-        accessor_registry.register(field_acc);
-
-        let mut action_table = ActionTable::new();
-        let id = action_table
-            .add(0u32, field, |x: &f32| *x + 10.0)
-            .with_interp(<f32 as Interpolation<()>>::interp)
-            .id();
-        let seg_col = action_table.ensure_segment_column::<f32>();
-        action_table.set_segment_by_column(
-            id,
-            Segment::new(0.0f32, 10.0f32),
-            seg_col,
-        );
-
-        let mut world = MockWorld(0.0);
-
-        sample_mock(
-            &action_table,
-            &accessor_registry,
-            &mut world,
-            &[(id, SampleMode::Start)],
-        );
-        assert_eq!(world.0, 0.0);
-
-        sample_mock(
-            &action_table,
-            &accessor_registry,
-            &mut world,
-            &[(id, SampleMode::End)],
-        );
-        assert_eq!(world.0, 10.0);
-
-        sample_mock(
-            &action_table,
-            &accessor_registry,
-            &mut world,
-            &[(id, SampleMode::Interp(0.5))],
-        );
-        assert!((world.0 - 5.0).abs() < f32::EPSILON);
-    }
-
-    /// The optional `EaseStorage` column must be probed too: a
-    /// present column should reshape `t` before interpolating.
-    #[test]
-    fn sample_join_applies_custom_ease() {
-        let field_acc = crate::path!(<f32>);
-        let field = field_acc.field.untyped();
-
-        let mut accessor_registry = AccessorRegistry::new();
-        accessor_registry.register(field_acc);
-
-        let mut action_table = ActionTable::new();
-        let id = action_table
-            .add(0u32, field, |x: &f32| *x + 10.0)
-            .with_interp(<f32 as Interpolation<()>>::interp)
-            .with_ease(motiongfx_interp::ease::quad::ease_in)
-            .id();
-        let seg_col = action_table.ensure_segment_column::<f32>();
-        action_table.set_segment_by_column(
-            id,
-            Segment::new(0.0f32, 10.0f32),
-            seg_col,
-        );
-        let mut world = MockWorld(0.0);
-        sample_mock(
-            &action_table,
-            &accessor_registry,
-            &mut world,
-            &[(id, SampleMode::Interp(0.5))],
-        );
-
-        // quad::ease_in(0.5) == 0.25, so the eased target is 2.5,
-        // not the unmodified-t value of 5.0.
-        assert!((world.0 - 2.5).abs() < f32::EPSILON);
-    }
 
     #[test]
     fn range_overlap_behavior() {

--- a/crates/motiongfx/src/pipeline/bake.rs
+++ b/crates/motiongfx/src/pipeline/bake.rs
@@ -1,0 +1,69 @@
+use crate::ThreadSafe;
+use crate::action::{ActionClip, ActionTable, Segment};
+use crate::registry::AccessorRegistry;
+use crate::subject::SubjectId;
+use crate::track::Track;
+use crate::world::SubjectSource;
+
+pub struct BakeCtx<'a, W> {
+    pub world: &'a W,
+    pub track: &'a Track,
+    pub action_table: &'a mut ActionTable,
+    pub accessor_registry: &'a AccessorRegistry,
+}
+
+pub fn bake<W, I, S, T>(ctx: BakeCtx<W>)
+where
+    W: SubjectSource<I, S>,
+    I: SubjectId,
+    S: 'static,
+    T: Clone + ThreadSafe,
+{
+    // Resolve the per-`T` columns once so the clip loop doesn't
+    // re-hash the `TypeId` on every access. No `T` action, no bake.
+    let Some(action_col) = ctx.action_table.action_column::<T>()
+    else {
+        return;
+    };
+    let segment_col = ctx.action_table.ensure_segment_column::<T>();
+
+    for (key, span) in ctx.track.sequences_spans() {
+        let Some(accessor) =
+            ctx.accessor_registry.get::<S, T>(key.field())
+        else {
+            continue;
+        };
+
+        let Some(&id) =
+            ctx.action_table.get_id(&key.subject_id().uid())
+        else {
+            continue;
+        };
+
+        let Some(source) = ctx.world.get_source(id) else {
+            continue;
+        };
+
+        let mut start = accessor.get_ref(source).clone();
+
+        for ActionClip { id, .. } in ctx.track.clips(*span) {
+            let Some(action) = ctx
+                .action_table
+                .get_action_by_column::<T>(action_col, id)
+            else {
+                continue;
+            };
+
+            let end = action(&start);
+            let segment = Segment::new(start.clone(), end.clone());
+
+            ctx.action_table.set_segment_by_column(
+                *id,
+                segment,
+                segment_col,
+            );
+
+            start = end;
+        }
+    }
+}

--- a/crates/motiongfx/src/pipeline/bake.rs
+++ b/crates/motiongfx/src/pipeline/bake.rs
@@ -1,69 +1,90 @@
+use field_path::field::UntypedField;
+use typarena::type_table::TypeTable;
+
 use crate::ThreadSafe;
-use crate::action::{ActionClip, ActionTable, Segment};
+use crate::action::{
+    ActionId, ActionTable, Segment, UntypedSubjectId,
+};
 use crate::registry::AccessorRegistry;
 use crate::subject::SubjectId;
-use crate::track::Track;
 use crate::world::SubjectSource;
 
-pub struct BakeCtx<'a, W> {
+/// Working copies of the sources touched during one bake pass.
+#[derive(Default)]
+pub struct BakeScratch {
+    sources: TypeTable<UntypedSubjectId>,
+}
+
+impl BakeScratch {
+    /// The working copy of `subject`'s source, seeded from `seed` the
+    /// first time it is asked for.
+    fn source<S: Clone + ThreadSafe>(
+        &mut self,
+        subject: UntypedSubjectId,
+        seed: impl FnOnce() -> Option<S>,
+    ) -> Option<&mut S> {
+        if !self.sources.contains::<S>(&subject) {
+            self.sources.insert::<S>(subject, seed()?);
+        }
+        // TODO: collapse this contains + insert + get_mut once
+        // typarena's `TypeTable` grows an entry API.
+        Some(
+            self.sources
+                .get_mut::<S>(&subject)
+                .expect("just inserted or already present"),
+        )
+    }
+}
+
+pub struct BakeClipCtx<'a, W> {
     pub world: &'a W,
-    pub track: &'a Track,
+    pub subject: UntypedSubjectId,
+    pub field: UntypedField,
+    pub action_id: ActionId,
+    pub scratch: &'a mut BakeScratch,
     pub action_table: &'a mut ActionTable,
     pub accessor_registry: &'a AccessorRegistry,
 }
 
-pub fn bake<W, I, S, T>(ctx: BakeCtx<W>)
+/// Bakes one clip's [`Segment`] against the source's working copy, so
+/// it composes on top of every earlier clip.
+pub fn bake_clip<W, I, S, T>(ctx: BakeClipCtx<'_, W>)
 where
     W: SubjectSource<I, S>,
     I: SubjectId,
-    S: 'static,
+    S: Clone + ThreadSafe,
     T: Clone + ThreadSafe,
 {
-    // Resolve the per-`T` columns once so the clip loop doesn't
-    // re-hash the `TypeId` on every access. No `T` action, no bake.
-    let Some(action_col) = ctx.action_table.action_column::<T>()
+    let Some(&subject_id) =
+        ctx.action_table.get_id::<I>(&ctx.subject.uid())
     else {
         return;
     };
-    let segment_col = ctx.action_table.ensure_segment_column::<T>();
+    let Some(accessor) =
+        ctx.accessor_registry.get::<S, T>(&ctx.field)
+    else {
+        return;
+    };
+    let Some(source) = ctx.scratch.source::<S>(ctx.subject, || {
+        ctx.world.get_source(subject_id).cloned()
+    }) else {
+        return;
+    };
+    let Some(action) =
+        ctx.action_table.get_action::<T>(&ctx.action_id)
+    else {
+        return;
+    };
 
-    for (key, span) in ctx.track.sequences_spans() {
-        let Some(accessor) =
-            ctx.accessor_registry.get::<S, T>(key.field())
-        else {
-            continue;
-        };
+    let start = accessor.get_ref(source).clone();
+    let end = action(&start);
 
-        let Some(&id) =
-            ctx.action_table.get_id(&key.subject_id().uid())
-        else {
-            continue;
-        };
+    let seg_col = ctx.action_table.ensure_segment_column::<T>();
+    ctx.action_table.set_segment_by_column(
+        ctx.action_id,
+        Segment::new(start, end.clone()),
+        seg_col,
+    );
 
-        let Some(source) = ctx.world.get_source(id) else {
-            continue;
-        };
-
-        let mut start = accessor.get_ref(source).clone();
-
-        for ActionClip { id, .. } in ctx.track.clips(*span) {
-            let Some(action) = ctx
-                .action_table
-                .get_action_by_column::<T>(action_col, id)
-            else {
-                continue;
-            };
-
-            let end = action(&start);
-            let segment = Segment::new(start.clone(), end.clone());
-
-            ctx.action_table.set_segment_by_column(
-                *id,
-                segment,
-                segment_col,
-            );
-
-            start = end;
-        }
-    }
+    *accessor.get_mut(source) = end;
 }

--- a/crates/motiongfx/src/pipeline/func_pointers.rs
+++ b/crates/motiongfx/src/pipeline/func_pointers.rs
@@ -1,24 +1,24 @@
-use crate::pipeline::bake::BakeCtx;
+use crate::pipeline::bake::BakeClipCtx;
 use crate::pipeline::sample::SampleCtx;
 
-/// A type-erased bake function pointer.
+/// A type-erased per-clip bake function pointer.
 #[derive(Debug, Clone, Copy)]
-pub struct BakeFnPtr(*const ());
+pub struct BakeClipFnPtr(*const ());
 
-unsafe impl Send for BakeFnPtr {}
-unsafe impl Sync for BakeFnPtr {}
+unsafe impl Send for BakeClipFnPtr {}
+unsafe impl Sync for BakeClipFnPtr {}
 
-impl BakeFnPtr {
-    pub const fn new<W>(f: BakeFn<W>) -> Self {
+impl BakeClipFnPtr {
+    pub const fn new<W>(f: BakeClipFn<W>) -> Self {
         Self(f as *const ())
     }
 
     /// # Safety
     ///
     /// `W` must match the type used when constructing this pointer.
-    pub const unsafe fn typed_unchecked<W>(&self) -> BakeFn<W> {
+    pub const unsafe fn typed_unchecked<W>(&self) -> BakeClipFn<W> {
         unsafe {
-            core::mem::transmute::<*const (), BakeFn<W>>(self.0)
+            core::mem::transmute::<*const (), BakeClipFn<W>>(self.0)
         }
     }
 }
@@ -45,5 +45,5 @@ impl SampleFnPtr {
     }
 }
 
-pub type BakeFn<W> = fn(BakeCtx<'_, W>);
+pub type BakeClipFn<W> = fn(BakeClipCtx<'_, W>);
 pub type SampleFn<W> = fn(SampleCtx<'_, W>);

--- a/crates/motiongfx/src/pipeline/func_pointers.rs
+++ b/crates/motiongfx/src/pipeline/func_pointers.rs
@@ -1,4 +1,5 @@
-use super::{BakeCtx, SampleCtx};
+use crate::pipeline::bake::BakeCtx;
+use crate::pipeline::sample::SampleCtx;
 
 /// A type-erased bake function pointer.
 #[derive(Debug, Clone, Copy)]

--- a/crates/motiongfx/src/pipeline/sample.rs
+++ b/crates/motiongfx/src/pipeline/sample.rs
@@ -1,0 +1,201 @@
+use crate::ThreadSafe;
+use crate::action::{
+    ActionId, ActionTable, InterpStorage, SampleMode, Segment,
+};
+use crate::registry::AccessorRegistry;
+use crate::subject::SubjectId;
+use crate::world::SubjectSource;
+
+pub struct SampleCtx<'a, W> {
+    pub world: &'a mut W,
+    pub action_table: &'a ActionTable,
+    pub accessor_registry: &'a AccessorRegistry,
+    /// The queued actions for this pipeline, each with its
+    /// [`SampleMode`] resolved at queue time.
+    pub samples: &'a [(ActionId, SampleMode)],
+}
+
+pub fn sample<W, I, S, T>(ctx: SampleCtx<W>)
+where
+    W: SubjectSource<I, S>,
+    I: SubjectId,
+    S: 'static,
+    T: Clone + ThreadSafe,
+{
+    let table = ctx.action_table.table();
+    let Some(segment_col) = table.type_column::<Segment<T>>() else {
+        return;
+    };
+    let Some(interp_col) = table.type_column::<InterpStorage<T>>()
+    else {
+        return;
+    };
+
+    for &(id, sample_mode) in ctx.samples {
+        let Some(segment) =
+            table.get_by_column::<Segment<T>>(segment_col, &id)
+        else {
+            continue;
+        };
+        let Some(interp) =
+            table.get_by_column::<InterpStorage<T>>(interp_col, &id)
+        else {
+            continue;
+        };
+
+        let Some(key) = ctx.action_table.key(&id) else {
+            continue;
+        };
+        let ease = ctx.action_table.ease(&id);
+        let Some(accessor) =
+            ctx.accessor_registry.get::<S, T>(key.field())
+        else {
+            continue;
+        };
+
+        let Some(&sid) =
+            ctx.action_table.get_id(&key.subject_id().uid())
+        else {
+            continue;
+        };
+
+        let target = match sample_mode {
+            SampleMode::Start => segment.start.clone(),
+            SampleMode::End => segment.end.clone(),
+            SampleMode::Interp(t) => {
+                let t = match ease {
+                    Some(ease) => ease.0(t),
+                    None => t,
+                };
+
+                interp.0(&segment.start, &segment.end, t)
+            }
+        };
+
+        ctx.world.apply_source(sid, |source| {
+            *accessor.get_mut(source) = target;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use motiongfx_interp::interpolation::Interpolation;
+
+    use super::*;
+
+    struct MockWorld(f32);
+
+    impl SubjectSource<u32, f32> for MockWorld {
+        fn get_source(&self, _id: u32) -> Option<&f32> {
+            Some(&self.0)
+        }
+
+        fn apply_source<R>(
+            &mut self,
+            _id: u32,
+            f: impl FnOnce(&mut f32) -> R,
+        ) -> Option<R> {
+            Some(f(&mut self.0))
+        }
+    }
+
+    fn sample_mock(
+        action_table: &ActionTable,
+        accessor_registry: &AccessorRegistry,
+        world: &mut MockWorld,
+        samples: &[(ActionId, SampleMode)],
+    ) {
+        sample::<MockWorld, u32, f32, f32>(SampleCtx {
+            world,
+            action_table,
+            accessor_registry,
+            samples,
+        });
+    }
+
+    /// Exercises the multi-column probe in `sample`: `ActionKey`,
+    /// `Segment<T>` and `InterpStorage<T>` are read per queued action,
+    /// with the `SampleMode` supplied by the queue.
+    #[test]
+    fn sample_join_reads_all_required_columns() {
+        let field_acc = crate::path!(<f32>);
+        let field = field_acc.field.untyped();
+
+        let mut accessor_registry = AccessorRegistry::new();
+        accessor_registry.register(field_acc);
+
+        let mut action_table = ActionTable::new();
+        let id = action_table
+            .add(0u32, field, |x: &f32| *x + 10.0)
+            .with_interp(<f32 as Interpolation<()>>::interp)
+            .id();
+        let seg_col = action_table.ensure_segment_column::<f32>();
+        action_table.set_segment_by_column(
+            id,
+            Segment::new(0.0f32, 10.0f32),
+            seg_col,
+        );
+
+        let mut world = MockWorld(0.0);
+
+        sample_mock(
+            &action_table,
+            &accessor_registry,
+            &mut world,
+            &[(id, SampleMode::Start)],
+        );
+        assert_eq!(world.0, 0.0);
+
+        sample_mock(
+            &action_table,
+            &accessor_registry,
+            &mut world,
+            &[(id, SampleMode::End)],
+        );
+        assert_eq!(world.0, 10.0);
+
+        sample_mock(
+            &action_table,
+            &accessor_registry,
+            &mut world,
+            &[(id, SampleMode::Interp(0.5))],
+        );
+        assert!((world.0 - 5.0).abs() < f32::EPSILON);
+    }
+
+    /// The optional `EaseStorage` column must be probed too: a
+    /// present column should reshape `t` before interpolating.
+    #[test]
+    fn sample_join_applies_custom_ease() {
+        let field_acc = crate::path!(<f32>);
+        let field = field_acc.field.untyped();
+
+        let mut accessor_registry = AccessorRegistry::new();
+        accessor_registry.register(field_acc);
+
+        let mut action_table = ActionTable::new();
+        let id = action_table
+            .add(0u32, field, |x: &f32| *x + 10.0)
+            .with_interp(<f32 as Interpolation<()>>::interp)
+            .with_ease(motiongfx_interp::ease::quad::ease_in)
+            .id();
+        let seg_col = action_table.ensure_segment_column::<f32>();
+        action_table.set_segment_by_column(
+            id,
+            Segment::new(0.0f32, 10.0f32),
+            seg_col,
+        );
+        let mut world = MockWorld(0.0);
+        sample_mock(
+            &action_table,
+            &accessor_registry,
+            &mut world,
+            &[(id, SampleMode::Interp(0.5))],
+        );
+
+        // quad::ease_in(0.5) == 0.25, so the eased target is 2.5,
+        // not the unmodified-t value of 5.0.
+        assert!((world.0 - 2.5).abs() < f32::EPSILON);
+    }
+}

--- a/crates/motiongfx/src/registry.rs
+++ b/crates/motiongfx/src/registry.rs
@@ -6,7 +6,7 @@ use field_path::field_accessor::FieldAccessor;
 use hashbrown::HashMap;
 
 use crate::ThreadSafe;
-use crate::pipeline::bake::BakeCtx;
+use crate::pipeline::bake::BakeClipCtx;
 use crate::pipeline::sample::SampleCtx;
 use crate::pipeline::{
     Pipeline, PipelineHandle, PipelineKey, PipelineUntyped,
@@ -33,7 +33,7 @@ impl Registry {
     ) where
         W: SubjectSource<I, S> + 'static,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: Clone + ThreadSafe,
     {
         self.accessor.register(field_acc);
@@ -107,10 +107,10 @@ impl PipelineRegistry {
         }
     }
 
-    pub(crate) fn bake<W: 'static>(
+    pub(crate) fn bake_clip<W: 'static>(
         &self,
         key: &PipelineKey,
-        ctx: BakeCtx<W>,
+        ctx: BakeClipCtx<W>,
     ) -> bool {
         if key.world_id() != TypeId::of::<W>() {
             return false;
@@ -118,7 +118,7 @@ impl PipelineRegistry {
 
         if let Some(pipeline) = self.pipelines.get(key) {
             // SAFETY: verified above that key.world_id == TypeId::of::<W>().
-            unsafe { pipeline.bake(ctx) };
+            unsafe { pipeline.bake_clip(ctx) };
             return true;
         }
 
@@ -149,7 +149,7 @@ impl PipelineRegistry {
     where
         W: SubjectSource<I, S> + 'static,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: Clone + ThreadSafe,
     {
         let key = PipelineHandle::<W, I, S, T>::new().as_key();

--- a/crates/motiongfx/src/registry.rs
+++ b/crates/motiongfx/src/registry.rs
@@ -6,9 +6,10 @@ use field_path::field_accessor::FieldAccessor;
 use hashbrown::HashMap;
 
 use crate::ThreadSafe;
+use crate::pipeline::bake::BakeCtx;
+use crate::pipeline::sample::SampleCtx;
 use crate::pipeline::{
-    BakeCtx, Pipeline, PipelineHandle, PipelineKey, PipelineUntyped,
-    SampleCtx,
+    Pipeline, PipelineHandle, PipelineKey, PipelineUntyped,
 };
 use crate::prelude::{SubjectSource, TimelineBuilder};
 use crate::subject::SubjectId;

--- a/crates/motiongfx/src/time.rs
+++ b/crates/motiongfx/src/time.rs
@@ -75,10 +75,22 @@ mod tests {
 
     #[test]
     fn range_overlap_counts_boundary_touch() {
-        let a = Range { start: s(0), end: s(5) };
-        let b = Range { start: s(3), end: s(8) };
-        let c = Range { start: s(6), end: s(10) };
-        let touching = Range { start: s(5), end: s(5) };
+        let a = Range {
+            start: s(0),
+            end: s(5),
+        };
+        let b = Range {
+            start: s(3),
+            end: s(8),
+        };
+        let c = Range {
+            start: s(6),
+            end: s(10),
+        };
+        let touching = Range {
+            start: s(5),
+            end: s(5),
+        };
 
         assert!(a.overlap(&b));
         assert!(!a.overlap(&c));
@@ -87,14 +99,29 @@ mod tests {
 
     #[test]
     fn range_intersect_drops_boundary_touch() {
-        let a = Range { start: s(0), end: s(5) };
-        let b = Range { start: s(3), end: s(8) };
-        let c = Range { start: s(6), end: s(10) };
-        let touching = Range { start: s(5), end: s(8) };
+        let a = Range {
+            start: s(0),
+            end: s(5),
+        };
+        let b = Range {
+            start: s(3),
+            end: s(8),
+        };
+        let c = Range {
+            start: s(6),
+            end: s(10),
+        };
+        let touching = Range {
+            start: s(5),
+            end: s(8),
+        };
 
         assert_eq!(
             a.intersect(&b),
-            Some(Range { start: s(3), end: s(5) }),
+            Some(Range {
+                start: s(3),
+                end: s(5)
+            }),
         );
         assert_eq!(a.intersect(&c), None);
         assert_eq!(a.intersect(&touching), None);

--- a/crates/motiongfx/src/time.rs
+++ b/crates/motiongfx/src/time.rs
@@ -38,6 +38,29 @@ pub const fn ns(nanos: u64) -> Duration {
     Duration::from_nanos(nanos)
 }
 
+/// A half-open time span `[start, end)`.
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Range {
+    pub start: Duration,
+    pub end: Duration,
+}
+
+impl Range {
+    /// True when the two [`Range`]s share any point, including a
+    /// boundary-only touch.
+    pub fn overlap(&self, other: &Self) -> bool {
+        self.start <= other.end && other.start <= self.end
+    }
+
+    /// The span shared by both [`Range`]s, or `None` when they share
+    /// no span of positive length. A boundary-only touch is `None`.
+    pub fn intersect(&self, other: &Self) -> Option<Self> {
+        let start = self.start.max(other.start);
+        let end = self.end.min(other.end);
+        (start < end).then_some(Self { start, end })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,5 +71,32 @@ mod tests {
         assert_eq!(cs(150), ms(1_500));
         assert_eq!(ms(1), ns(1_000_000));
         assert_eq!(cs(u64::MAX), Duration::from_millis(u64::MAX));
+    }
+
+    #[test]
+    fn range_overlap_counts_boundary_touch() {
+        let a = Range { start: s(0), end: s(5) };
+        let b = Range { start: s(3), end: s(8) };
+        let c = Range { start: s(6), end: s(10) };
+        let touching = Range { start: s(5), end: s(5) };
+
+        assert!(a.overlap(&b));
+        assert!(!a.overlap(&c));
+        assert!(a.overlap(&touching));
+    }
+
+    #[test]
+    fn range_intersect_drops_boundary_touch() {
+        let a = Range { start: s(0), end: s(5) };
+        let b = Range { start: s(3), end: s(8) };
+        let c = Range { start: s(6), end: s(10) };
+        let touching = Range { start: s(5), end: s(8) };
+
+        assert_eq!(
+            a.intersect(&b),
+            Some(Range { start: s(3), end: s(5) }),
+        );
+        assert_eq!(a.intersect(&c), None);
+        assert_eq!(a.intersect(&touching), None);
     }
 }

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -13,7 +13,9 @@ use crate::action::{
     Action, ActionBuilder, ActionId, ActionKey, ActionTable,
     InterpActionBuilder, SampleMode,
 };
-use crate::pipeline::{BakeCtx, PipelineKey, Range, SampleCtx};
+use crate::pipeline::bake::BakeCtx;
+use crate::pipeline::sample::SampleCtx;
+use crate::pipeline::{PipelineKey, Range};
 use crate::registry::Registry;
 use crate::subject::SubjectId;
 use crate::track::{Track, TrackList};

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -40,6 +40,23 @@ pub struct Timeline<W> {
     _marker: PhantomData<fn() -> W>,
 }
 
+/// A track switch only ever samples a sequence's first or last clip,
+/// never mid-clip.
+#[derive(Clone, Copy)]
+enum BoundaryMode {
+    Start,
+    End,
+}
+
+impl From<BoundaryMode> for SampleMode {
+    fn from(mode: BoundaryMode) -> Self {
+        match mode {
+            BoundaryMode::Start => Self::Start,
+            BoundaryMode::End => Self::End,
+        }
+    }
+}
+
 /// One field's resolved sample for the current frame.
 #[derive(Debug, Clone, Copy)]
 struct QueuedSample {
@@ -112,20 +129,20 @@ impl<W: 'static> Timeline<W> {
 
         // Handle index changes.
         if self.target_index() != self.curr_index() {
-            let (sample_mode, track_range) = if self.target_index()
+            let (boundary, track_range) = if self.target_index()
                 > self.curr_index()
             {
                 // From the start.
                 curr_time = Duration::ZERO;
                 (
-                    SampleMode::End,
+                    BoundaryMode::End,
                     self.curr_index()..self.target_index(),
                 )
             } else {
                 // From the end.
                 curr_time = self.tracks[self.target_index].duration();
                 (
-                    SampleMode::Start,
+                    BoundaryMode::Start,
                     (self.target_index() + 1)
                         ..(self.curr_index() + 1),
                 )
@@ -139,14 +156,13 @@ impl<W: 'static> Timeline<W> {
 
                     let clips = self.tracks[i].clips(*span);
 
-                    let entry = match sample_mode {
-                        SampleMode::Start => {
+                    let entry = match boundary {
+                        BoundaryMode::Start => {
                             clips.first().map(|c| (c, c.start))
                         }
-                        SampleMode::End => {
+                        BoundaryMode::End => {
                             clips.last().map(|c| (c, c.end()))
                         }
-                        SampleMode::Interp(_) => unreachable!(),
                     };
                     let Some((clip, keyframe)) = entry else {
                         continue;
@@ -156,7 +172,7 @@ impl<W: 'static> Timeline<W> {
                         *key,
                         QueuedSample {
                             id: clip.id,
-                            mode: sample_mode,
+                            mode: boundary.into(),
                             keyframe,
                         },
                     );

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -3,9 +3,9 @@ use core::marker::PhantomData;
 use core::time::Duration;
 
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use field_path::field_accessor::FieldAccessor;
-use hashbrown::HashMap;
+use hashbrown::{DefaultHashBuilder, HashMap};
+use indexmap::IndexMap;
 use motiongfx_interp::interpolation::Interpolation;
 
 use crate::ThreadSafe;
@@ -26,16 +26,9 @@ pub struct Timeline<W> {
     /// Track length is guaranteed to be at least 1 by construction.
     /// See [`TimelineBuilder::compile()`].
     tracks: Box<[Track]>,
-    /// Cached actions that are queued to be sampled.
-    ///
-    /// This cache will be cleared everytime [`Timeline::queue_actions`]
-    /// is called.
-    queue_cache: QueueCache,
-    /// Queued actions grouped by pipeline, each carrying its resolved
-    /// [`SampleMode`]. Rebuilt from `queue_cache` every
-    /// [`Timeline::queue_actions`] so sampling touches only the marked
-    /// actions of each type, with no per-action column lookup.
-    sample_queue: HashMap<PipelineKey, Vec<(ActionId, SampleMode)>>,
+    /// Fields to sample this frame, deduped per field and ordered so
+    /// overlapping writes to aliasing memory resolve deterministically.
+    queue: IndexMap<ActionKey, QueuedSample, DefaultHashBuilder>,
     /// The current time of the current track.
     curr_time: Duration,
     /// The target time of the target track.
@@ -45,6 +38,15 @@ pub struct Timeline<W> {
     /// The index of the target track.
     target_index: usize,
     _marker: PhantomData<fn() -> W>,
+}
+
+/// One field's resolved sample for the current frame.
+#[derive(Debug, Clone, Copy)]
+struct QueuedSample {
+    id: ActionId,
+    mode: SampleMode,
+    /// Start of the clip this resolved to.
+    clip_start: Duration,
 }
 
 impl<W: 'static> Timeline<W> {
@@ -100,7 +102,7 @@ impl<W: 'static> Timeline<W> {
             return;
         }
 
-        self.reset_queues();
+        self.queue.clear();
         // Current time will change if the track index changes.
         let mut curr_time = self.curr_time();
 
@@ -140,10 +142,13 @@ impl<W: 'static> Timeline<W> {
                         SampleMode::Interp(_) => unreachable!(),
                     };
 
-                    self.queue_cache.cache(
+                    self.queue.insert(
                         *key,
-                        clip.id,
-                        sample_mode,
+                        QueuedSample {
+                            id: clip.id,
+                            mode: sample_mode,
+                            clip_start: clip.start,
+                        },
                     );
                 }
             }
@@ -196,12 +201,15 @@ impl<W: 'static> Timeline<W> {
                 Ok(index) => {
                     let clip = &clips[index];
 
-                    self.queue_cache.cache(
+                    self.queue.insert(
                         *key,
-                        clip.id,
-                        SampleMode::Interp(
-                            clip.progress(self.target_time),
-                        ),
+                        QueuedSample {
+                            id: clip.id,
+                            mode: SampleMode::Interp(
+                                clip.progress(self.target_time),
+                            ),
+                            clip_start: clip.start,
+                        },
                     );
                 }
                 // `target_time` is out of bounds.
@@ -227,67 +235,59 @@ impl<W: 'static> Timeline<W> {
                         SampleMode::End
                     };
 
-                    self.queue_cache.cache(
+                    self.queue.insert(
                         *key,
-                        clip.id,
-                        sample_mode,
+                        QueuedSample {
+                            id: clip.id,
+                            mode: sample_mode,
+                            clip_start: clip.start,
+                        },
                     );
                 }
             }
         }
 
-        // Group the deduped queue by pipeline so each typed sampler
-        // iterates only its own actions, with the `SampleMode` in hand.
-        for (key, &(id, sample_mode)) in self.queue_cache.iter() {
-            let pkey = PipelineKey::from_action_key::<W>(*key);
-            self.sample_queue
-                .entry(pkey)
-                .or_default()
-                .push((id, sample_mode));
-        }
+        // `Start`/`End` before the frame's `Interp`, then by clip
+        // start, so overlapping writes to aliasing memory land the
+        // same way every frame.
+        self.queue.sort_unstable_by(|_, a, _, b| {
+            let key = |q: &QueuedSample| {
+                (
+                    matches!(q.mode, SampleMode::Interp(_)),
+                    q.clip_start,
+                )
+            };
+            key(a).cmp(&key(b))
+        });
 
         self.curr_time = self.target_time;
     }
 
+    /// Writes every sample marked by [`Self::queue_actions`] into the
+    /// world.
     pub fn sample_queued_actions(
         &self,
         registry: &Registry,
         subject_world: &mut W,
     ) {
-        for (key, samples) in self.sample_queue.iter() {
-            if samples.is_empty() {
-                continue;
-            }
+        for (key, queued) in &self.queue {
+            let pkey = PipelineKey::from_action_key::<W>(*key);
             let ok = registry.pipeline.sample(
-                key,
+                &pkey,
                 SampleCtx {
                     world: subject_world,
                     action_table: &self.action_table,
                     accessor_registry: &registry.accessor,
-                    samples,
+                    samples: &[(queued.id, queued.mode)],
                 },
             );
-            debug_assert!(ok, "pipeline not found for key {key:?}");
-        }
-    }
-
-    fn reset_queues(&mut self) {
-        self.queue_cache.clear();
-        // Retain the per-pipeline `Vec` capacities across frames.
-        for samples in self.sample_queue.values_mut() {
-            samples.clear();
+            debug_assert!(ok, "pipeline not found for key {pkey:?}");
         }
     }
 }
 
 // Getter methods.
 impl<W> Timeline<W> {
-    /// Returns the current queue cache.
-    #[inline]
-    pub fn queue_cache(&self) -> &QueueCache {
-        &self.queue_cache
-    }
-
     /// Returns the current playback time.
     #[inline]
     pub fn curr_time(&self) -> Duration {
@@ -403,66 +403,6 @@ impl<W> Timeline<W> {
 
         self.target_index = target_index.clamp(0, max_index);
         self
-    }
-}
-
-/// Cached actions that are queued to be sampled.
-///
-/// This cache prevents duplicated samples on the same [`ActionKey`]
-/// which result in sampling the same target field on the same entity
-/// more than once. This is crucial as the sampling pipeline happens
-/// in an unordered manner.
-#[derive(Debug)]
-pub struct QueueCache {
-    cache: HashMap<ActionKey, (ActionId, SampleMode)>,
-}
-
-impl QueueCache {
-    pub fn new() -> Self {
-        Self {
-            cache: HashMap::new(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.cache.is_empty()
-    }
-
-    pub fn iter(
-        &self,
-    ) -> impl Iterator<Item = (&ActionKey, &(ActionId, SampleMode))>
-    {
-        self.cache.iter()
-    }
-
-    pub fn iter_keys(&self) -> impl Iterator<Item = &ActionKey> {
-        self.cache.keys()
-    }
-
-    pub fn iter_ids(&self) -> impl Iterator<Item = ActionId> + '_ {
-        self.cache.values().map(|(id, _)| *id)
-    }
-
-    /// Clear all the cached contents.
-    pub fn clear(&mut self) {
-        self.cache.clear();
-    }
-
-    /// Cache an [`ActionKey`] with its [`SampleMode`], overwriting any
-    /// previous entry for the same key (dedup per field per subject).
-    pub fn cache(
-        &mut self,
-        key: ActionKey,
-        id: ActionId,
-        sample_mode: SampleMode,
-    ) {
-        self.cache.insert(key, (id, sample_mode));
-    }
-}
-
-impl Default for QueueCache {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -592,8 +532,7 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
         Timeline {
             action_table: self.action_table,
             tracks: tracks.into().into_boxed_slice(),
-            queue_cache: QueueCache::new(),
-            sample_queue: HashMap::new(),
+            queue: IndexMap::default(),
             curr_time: Duration::ZERO,
             target_time: Duration::ZERO,
             curr_index: 0,

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -250,7 +250,7 @@ impl<W: 'static> Timeline<W> {
                         start: clip.start,
                         end: clip.end(),
                     };
-                    // Skip if the the animation range does not
+                    // Skip if the animation range does not
                     // overlap with the span range.
                     if !time_range.overlap(&clip_range) {
                         continue;
@@ -355,10 +355,10 @@ impl<W> Timeline<W> {
         self.tracks.iter().flat_map(Track::conflicts)
     }
 
-    /// Returns a reference the current playing track.
+    /// Returns a reference to the current playing track.
     #[inline]
     pub fn curr_track(&self) -> &Track {
-        // SAFETY: Track length is garuanteed to be at least 1.
+        // SAFETY: Track length is guaranteed to be at least 1.
         &self.tracks[self.curr_index]
     }
 
@@ -366,7 +366,7 @@ impl<W> Timeline<W> {
     /// index you can provide in [`Timeline::set_target_track`].
     #[inline]
     pub fn last_track_index(&self) -> usize {
-        // SAFETY: Track length is garuanteed to be at least 1.
+        // SAFETY: Track length is guaranteed to be at least 1.
         self.tracks.len() - 1
     }
 
@@ -380,7 +380,7 @@ impl<W> Timeline<W> {
     /// [`Self::curr_index()`]?
     #[inline]
     pub fn is_track_end(&self) -> bool {
-        // SAFETY: Track length is garuanteed to be at least 1.
+        // SAFETY: Track length is guaranteed to be at least 1.
         self.curr_time >= self.tracks[self.curr_index()].duration()
     }
 
@@ -393,7 +393,7 @@ impl<W> Timeline<W> {
 
 // Setter methods.
 impl<W> Timeline<W> {
-    /// Set the target time of the current track, clamping the value
+    /// Set the target time of the target track, clamping the value
     /// within \[0.0..=track.duration\]
     pub fn set_target_time(
         &mut self,

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -13,7 +13,7 @@ use crate::action::{
     Action, ActionBuilder, ActionId, ActionKey, ActionTable,
     InterpActionBuilder, SampleMode,
 };
-use crate::pipeline::bake::BakeCtx;
+use crate::pipeline::bake::{BakeClipCtx, BakeScratch};
 use crate::pipeline::sample::SampleCtx;
 use crate::pipeline::{PipelineKey, Range};
 use crate::registry::Registry;
@@ -23,7 +23,6 @@ use crate::world::SubjectSource;
 
 pub struct Timeline<W> {
     action_table: ActionTable,
-    pipeline_counts: Box<[(PipelineKey, u32)]>,
     /// Track length is guaranteed to be at least 1 by construction.
     /// See [`TimelineBuilder::compile()`].
     tracks: Box<[Track]>,
@@ -49,25 +48,40 @@ pub struct Timeline<W> {
 }
 
 impl<W: 'static> Timeline<W> {
+    /// Bakes every clip's [`Segment`](crate::action::Segment). Clips
+    /// are visited in start-time order over a per-track working copy
+    /// of each source, so an action composes on top of every earlier
+    /// one.
     pub fn bake_actions(
         &mut self,
         registry: &Registry,
         subject_world: &W,
     ) {
-        for key in self.pipeline_counts.iter().map(|(key, _)| key) {
-            for track in self.tracks.iter() {
-                let ok = registry.pipeline.bake(
-                    key,
-                    BakeCtx {
+        for track in self.tracks.iter() {
+            let mut scratch = BakeScratch::default();
+
+            for clip in track.bake_clips() {
+                let Some(key) =
+                    self.action_table.key(&clip.id).copied()
+                else {
+                    continue;
+                };
+                let pkey = PipelineKey::from_action_key::<W>(key);
+                let ok = registry.pipeline.bake_clip(
+                    &pkey,
+                    BakeClipCtx {
                         world: subject_world,
-                        track,
+                        subject: *key.subject_id(),
+                        field: *key.field(),
+                        action_id: clip.id,
+                        scratch: &mut scratch,
                         action_table: &mut self.action_table,
                         accessor_registry: &registry.accessor,
                     },
                 );
                 debug_assert!(
                     ok,
-                    "pipeline not found for key {key:?}"
+                    "pipeline not found for key {pkey:?}"
                 );
             }
         }
@@ -478,7 +492,7 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
     where
         W: SubjectSource<I, S> + 'static,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: Interpolation<M> + Clone + ThreadSafe,
     {
         self.act_builder(target, field_acc, action)
@@ -495,7 +509,7 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
     where
         W: SubjectSource<I, S> + 'static,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: Clone + ThreadSafe,
     {
         self.act_builder(target, field_acc, action).with_interp(
@@ -516,7 +530,7 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
     where
         W: SubjectSource<I, S> + 'static,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: Clone + ThreadSafe,
     {
         let field = field_acc.field;
@@ -564,12 +578,10 @@ impl<'a, W: 'static> TimelineBuilder<'a, W> {
         self,
         tracks: impl Into<TrackList>,
     ) -> Timeline<W> {
+        // `pipeline_counts` is builder-only; baking resolves a
+        // pipeline per clip.
         Timeline {
             action_table: self.action_table,
-            pipeline_counts: self
-                .pipeline_counts
-                .into_iter()
-                .collect(),
             tracks: tracks.into().into_boxed_slice(),
             queue_cache: QueueCache::new(),
             sample_queue: HashMap::new(),

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -45,8 +45,12 @@ pub struct Timeline<W> {
 struct QueuedSample {
     id: ActionId,
     mode: SampleMode,
-    /// Start of the clip this resolved to.
-    clip_start: Duration,
+    /// The instant this sample represents.
+    ///
+    /// The clip's start for [`SampleMode::Start`] or end for
+    /// [`SampleMode::End`], the playhead itself for
+    /// [`SampleMode::Interp`].
+    keyframe: Duration,
 }
 
 impl<W: 'static> Timeline<W> {
@@ -135,11 +139,17 @@ impl<W: 'static> Timeline<W> {
 
                     let clips = self.tracks[i].clips(*span);
 
-                    // SAFETY: `clips` is not empty.
-                    let clip = match sample_mode {
-                        SampleMode::Start => clips.first().unwrap(),
-                        SampleMode::End => clips.last().unwrap(),
+                    let entry = match sample_mode {
+                        SampleMode::Start => {
+                            clips.first().map(|c| (c, c.start))
+                        }
+                        SampleMode::End => {
+                            clips.last().map(|c| (c, c.end()))
+                        }
                         SampleMode::Interp(_) => unreachable!(),
+                    };
+                    let Some((clip, keyframe)) = entry else {
+                        continue;
                     };
 
                     self.queue.insert(
@@ -147,7 +157,7 @@ impl<W: 'static> Timeline<W> {
                         QueuedSample {
                             id: clip.id,
                             mode: sample_mode,
-                            clip_start: clip.start,
+                            keyframe,
                         },
                     );
                 }
@@ -170,10 +180,14 @@ impl<W: 'static> Timeline<W> {
 
             let clips = self.tracks[self.curr_index].clips(*span);
 
-            // SAFETY: `clips` is not empty.
+            let (Some(first), Some(last)) =
+                (clips.first(), clips.last())
+            else {
+                continue;
+            };
             let clips_range = Range {
-                start: clips.first().unwrap().start,
-                end: clips.last().unwrap().end(),
+                start: first.start,
+                end: last.end(),
             };
 
             if !time_range.overlap(&clips_range) {
@@ -208,7 +222,7 @@ impl<W: 'static> Timeline<W> {
                             mode: SampleMode::Interp(
                                 clip.progress(self.target_time),
                             ),
-                            clip_start: clip.start,
+                            keyframe: self.target_time,
                         },
                     );
                 }
@@ -229,10 +243,10 @@ impl<W: 'static> Timeline<W> {
                     // Target time before the sequence -> Start,
                     // otherwise it is past `index - 1` -> End (the
                     // saturating sub above handles the indexing).
-                    let sample_mode = if index == 0 {
-                        SampleMode::Start
+                    let (sample_mode, keyframe) = if index == 0 {
+                        (SampleMode::Start, clip.start)
                     } else {
-                        SampleMode::End
+                        (SampleMode::End, clip.end())
                     };
 
                     self.queue.insert(
@@ -240,24 +254,22 @@ impl<W: 'static> Timeline<W> {
                         QueuedSample {
                             id: clip.id,
                             mode: sample_mode,
-                            clip_start: clip.start,
+                            keyframe,
                         },
                     );
                 }
             }
         }
 
-        // `Start`/`End` before the frame's `Interp`, then by clip
-        // start, so overlapping writes to aliasing memory land the
-        // same way every frame.
+        // Farthest keyframe first, closest last, so overlapping
+        // writes to aliasing memory land on the value nearest the
+        // playhead every frame. `Interp` sits exactly on the playhead
+        // (distance zero), so it always sorts last on its own.
+        let target_time = self.target_time;
         self.queue.sort_unstable_by(|_, a, _, b| {
-            let key = |q: &QueuedSample| {
-                (
-                    matches!(q.mode, SampleMode::Interp(_)),
-                    q.clip_start,
-                )
-            };
-            key(a).cmp(&key(b))
+            target_time
+                .abs_diff(b.keyframe)
+                .cmp(&target_time.abs_diff(a.keyframe))
         });
 
         self.curr_time = self.target_time;

--- a/crates/motiongfx/src/timeline.rs
+++ b/crates/motiongfx/src/timeline.rs
@@ -318,6 +318,15 @@ impl<W> Timeline<W> {
         &self.tracks
     }
 
+    /// Every clip dropped across the tracks to resolve overlapping
+    /// actions on aliasing field paths.
+    #[cfg(feature = "diagnostics")]
+    pub fn conflicts(
+        &self,
+    ) -> impl Iterator<Item = &crate::track::FieldConflict> {
+        self.tracks.iter().flat_map(Track::conflicts)
+    }
+
     /// Returns a reference the current playing track.
     #[inline]
     pub fn curr_track(&self) -> &Track {

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -966,10 +966,7 @@ mod tests {
             let id = ids(2);
             // `""` (the source) aliases `::x`; the later clip overlaps.
             let track = TrackFragment::new()
-                .upsert_sequence(
-                    key(""),
-                    seq(&[clip(id[0], 0, 100)]),
-                )
+                .upsert_sequence(key(""), seq(&[clip(id[0], 0, 100)]))
                 .upsert_sequence(
                     key("::x"),
                     seq(&[clip(id[1], 50, 100)]),
@@ -986,10 +983,7 @@ mod tests {
 
             let id = ids(2);
             let track = TrackFragment::new()
-                .upsert_sequence(
-                    key(""),
-                    seq(&[clip(id[0], 0, 100)]),
-                )
+                .upsert_sequence(key(""), seq(&[clip(id[0], 0, 100)]))
                 .upsert_sequence(
                     key("::x"),
                     seq(&[clip(id[1], 50, 100)]),
@@ -1002,11 +996,17 @@ mod tests {
             assert_eq!(conflicts[0].winner, id[1]);
             assert_eq!(
                 conflicts[0].dropped_span,
-                Range { start: cs(0), end: cs(100) },
+                Range {
+                    start: cs(0),
+                    end: cs(100)
+                },
             );
             assert_eq!(
                 conflicts[0].overlap,
-                Range { start: cs(50), end: cs(100) },
+                Range {
+                    start: cs(50),
+                    end: cs(100)
+                },
             );
         }
     }

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -352,10 +352,9 @@ fn resolve_conflicts(
     #[cfg(feature = "diagnostics")]
     let mut conflicts = Vec::new();
 
-    for (i, (key_a, seq_a)) in sequences.iter().enumerate() {
-        for (j, (key_b, seq_b)) in sequences.iter().enumerate() {
-            if i == j
-                || key_a.subject_id() != key_b.subject_id()
+    for (key_a, seq_a) in sequences.iter() {
+        for (key_b, seq_b) in sequences.iter() {
+            if key_a.subject_id() != key_b.subject_id()
                 || key_a.field().source_id()
                     != key_b.field().source_id()
                 || !paths_alias(
@@ -968,6 +967,25 @@ mod tests {
             // `""` (the source) aliases `::x`; the later clip overlaps.
             let track = TrackFragment::new()
                 .upsert_sequence(key(""), seq(&[clip(id[0], 0, 100)]))
+                .upsert_sequence(
+                    key("::x"),
+                    seq(&[clip(id[1], 50, 100)]),
+                )
+                .compile();
+
+            assert_eq!(baked(&track), [id[1]]);
+        }
+
+        #[test]
+        fn overlapping_clips_under_one_key_drop_the_earlier() {
+            let id = ids(2);
+            // Both clips land on the same `ActionKey` via an upsert
+            // append and overlap in time; the later one wins outright.
+            let track = TrackFragment::new()
+                .upsert_sequence(
+                    key("::x"),
+                    seq(&[clip(id[0], 0, 100)]),
+                )
                 .upsert_sequence(
                     key("::x"),
                     seq(&[clip(id[1], 50, 100)]),

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -352,21 +352,22 @@ fn resolve_conflicts(
     #[cfg(feature = "diagnostics")]
     let mut conflicts = Vec::new();
 
-    for (i, (ka, sa)) in sequences.iter().enumerate() {
-        for (j, (kb, sb)) in sequences.iter().enumerate() {
+    for (i, (key_a, seq_a)) in sequences.iter().enumerate() {
+        for (j, (key_b, seq_b)) in sequences.iter().enumerate() {
             if i == j
-                || ka.subject_id() != kb.subject_id()
-                || ka.field().source_id() != kb.field().source_id()
+                || key_a.subject_id() != key_b.subject_id()
+                || key_a.field().source_id()
+                    != key_b.field().source_id()
                 || !paths_alias(
-                    ka.field().field_path(),
-                    kb.field().field_path(),
+                    key_a.field().field_path(),
+                    key_b.field().field_path(),
                 )
             {
                 continue;
             }
 
-            for ca in sa.clips.iter() {
-                for cb in sb.clips.iter() {
+            for ca in seq_a.clips.iter() {
+                for cb in seq_b.clips.iter() {
                     if cb.id > ca.id
                         && ca.start < cb.end()
                         && cb.start < ca.end()
@@ -375,13 +376,13 @@ fn resolve_conflicts(
                         #[cfg(feature = "diagnostics")]
                         conflicts.push(FieldConflict {
                             dropped: ca.id,
-                            dropped_field: *ka.field(),
+                            dropped_field: *key_a.field(),
                             dropped_span: Range {
                                 start: ca.start,
                                 end: ca.end(),
                             },
                             winner: cb.id,
-                            winner_field: *kb.field(),
+                            winner_field: *key_b.field(),
                             overlap: Range {
                                 start: ca.start.max(cb.start),
                                 end: ca.end().min(cb.end()),
@@ -390,10 +391,10 @@ fn resolve_conflicts(
                         #[cfg(feature = "tracing")]
                         tracing::warn!(
                             "dropping action on `{}` ({:?}..{:?}): a later action on `{}` overlaps it",
-                            ka.field().field_path(),
+                            key_a.field().field_path(),
                             ca.start,
                             ca.end(),
-                            kb.field().field_path(),
+                            key_b.field().field_path(),
                         );
                     }
                 }

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -3,10 +3,10 @@ use core::time::Duration;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use field_path::field::UntypedField;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use nonempty::NonEmpty;
 
-use crate::action::{ActionClip, ActionKey};
+use crate::action::{ActionClip, ActionId, ActionKey, paths_alias};
 use crate::sequence::Sequence;
 
 pub trait TrackOrdering {
@@ -214,11 +214,14 @@ impl TrackFragment {
         let mut sequences =
             self.sequences.into_iter().collect::<Vec<_>>();
 
+        resolve_conflicts(&mut sequences);
+
         if sequences.is_empty() {
             return Track {
                 field_lookups: Box::new([]),
                 sequence_spans: Box::new([]),
                 clip_arena: Box::new([]),
+                bake_order: Box::new([]),
                 duration: self.duration,
             };
         }
@@ -282,12 +285,23 @@ impl TrackFragment {
         let clip_arena = sequences
             .into_iter()
             .flat_map(|(_, clips)| clips)
-            .collect();
+            .collect::<Box<[_]>>();
+
+        // `clip_arena` stays grouped by sequence for the per-field
+        // spans; `bake_order` is the same clips in start-time order,
+        // ties by `ActionId`.
+        let mut bake_order =
+            (0..clip_arena.len() as u32).collect::<Box<[_]>>();
+        bake_order.sort_unstable_by_key(|&i| {
+            let clip = &clip_arena[i as usize];
+            (clip.start, clip.id)
+        });
 
         Track {
             field_lookups: field_lookups.into_boxed_slice(),
             sequence_spans: sequence_spans.into_boxed_slice(),
             clip_arena,
+            bake_order,
             duration,
         }
     }
@@ -297,6 +311,68 @@ impl Default for TrackFragment {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Drops any clip that a later-authored action on an aliasing field
+/// path of the same subject overlaps in time. The later action wins
+/// the whole clip, not just the overlapped span.
+fn resolve_conflicts(sequences: &mut Vec<(ActionKey, Sequence)>) {
+    let mut removed = HashSet::<ActionId>::new();
+
+    for (i, (ka, sa)) in sequences.iter().enumerate() {
+        for (j, (kb, sb)) in sequences.iter().enumerate() {
+            if i == j
+                || ka.subject_id() != kb.subject_id()
+                || ka.field().source_id() != kb.field().source_id()
+                || !paths_alias(
+                    ka.field().field_path(),
+                    kb.field().field_path(),
+                )
+            {
+                continue;
+            }
+
+            for ca in sa.clips.iter() {
+                for cb in sb.clips.iter() {
+                    if cb.id > ca.id
+                        && ca.start < cb.end()
+                        && cb.start < ca.end()
+                        && removed.insert(ca.id)
+                    {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "dropping action on `{}` ({:?}..{:?}): a later action on `{}` overlaps it",
+                            ka.field().field_path(),
+                            ca.start,
+                            ca.end(),
+                            kb.field().field_path(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    if removed.is_empty() {
+        return;
+    }
+
+    sequences.retain_mut(|(_, seq)| {
+        let kept = seq
+            .clips
+            .iter()
+            .copied()
+            .filter(|clip| !removed.contains(&clip.id))
+            .collect::<Vec<_>>();
+
+        match NonEmpty::from_vec(kept) {
+            Some(clips) => {
+                seq.clips = clips;
+                true
+            }
+            None => false,
+        }
+    });
 }
 
 /// A compiled dense action sequences, optimized for playback and
@@ -323,6 +399,9 @@ pub struct Track {
 
     /// Contiguous storage of all action clips.
     clip_arena: Box<[ActionClip]>,
+
+    /// `clip_arena` indices in start-time order, ties by `ActionId`.
+    bake_order: Box<[u32]>,
 
     /// Total duration of the track.
     ///
@@ -361,6 +440,16 @@ impl Track {
     #[inline]
     pub fn clips(&self, span: Span) -> &[ActionClip] {
         &self.clip_arena[span.offset..span.offset + span.len]
+    }
+
+    /// Every clip in start-time order, ties broken by `ActionId`.
+    #[inline]
+    pub fn bake_clips(
+        &self,
+    ) -> impl Iterator<Item = &ActionClip> + '_ {
+        self.bake_order
+            .iter()
+            .map(|&i| &self.clip_arena[i as usize])
     }
 
     #[inline]
@@ -684,5 +773,128 @@ mod tests {
             covered, lanes,
             "field spans must cover every lane"
         );
+    }
+
+    mod bake_order {
+        use typarena::id::IdGenerator;
+
+        use crate::action::ActionMarker;
+
+        use super::*;
+
+        /// Distinct, monotonically increasing [`ActionId`]s.
+        fn ids(count: usize) -> Vec<ActionId> {
+            let mut id_gen = IdGenerator::<ActionMarker>::new();
+            (0..count).map(|_| id_gen.new_id()).collect()
+        }
+
+        fn clip(id: ActionId, start: u64, dur: u64) -> ActionClip {
+            ActionClip {
+                id,
+                start: cs(start),
+                duration: cs(dur),
+            }
+        }
+
+        fn seq(clips: &[ActionClip]) -> Sequence {
+            let mut seq = Sequence::new(clips[0]);
+            for &clip in &clips[1..] {
+                seq.push(clip);
+            }
+            seq
+        }
+
+        /// The order `Track::bake_clips` yields.
+        fn baked(track: &Track) -> Vec<ActionId> {
+            track.bake_clips().map(|clip| clip.id).collect()
+        }
+
+        #[test]
+        fn sorts_clips_across_sequences_by_start_time() {
+            let id = ids(5);
+            let track = TrackFragment::new()
+                .upsert_sequence(
+                    key("a"),
+                    seq(&[
+                        clip(id[0], 0, 100),
+                        clip(id[3], 200, 100),
+                    ]),
+                )
+                .upsert_sequence(
+                    key("b"),
+                    seq(&[clip(id[1], 0, 50), clip(id[2], 100, 100)]),
+                )
+                .upsert_sequence(
+                    key("c"),
+                    seq(&[clip(id[4], 50, 20)]),
+                )
+                .compile();
+
+            assert_eq!(
+                baked(&track),
+                [id[0], id[1], id[4], id[2], id[3]],
+            );
+        }
+
+        #[test]
+        fn breaks_start_ties_by_action_id() {
+            let id = ids(3);
+            // Three sequences, every clip starting at the same instant.
+            let track = TrackFragment::new()
+                .upsert_sequence(key("c"), seq(&[clip(id[2], 0, 10)]))
+                .upsert_sequence(key("a"), seq(&[clip(id[0], 0, 10)]))
+                .upsert_sequence(key("b"), seq(&[clip(id[1], 0, 10)]))
+                .compile();
+
+            assert_eq!(baked(&track), [id[0], id[1], id[2]]);
+        }
+
+        #[test]
+        fn yields_every_clip_exactly_once() {
+            let id = ids(4);
+            let track = TrackFragment::new()
+                .upsert_sequence(
+                    key("a"),
+                    seq(&[
+                        clip(id[0], 0, 100),
+                        clip(id[1], 100, 100),
+                        clip(id[2], 200, 100),
+                    ]),
+                )
+                .upsert_sequence(
+                    key("b"),
+                    seq(&[clip(id[3], 50, 20)]),
+                )
+                .compile();
+
+            let mut baked = baked(&track);
+            baked.sort_unstable();
+            let mut all = id.clone();
+            all.sort_unstable();
+            assert_eq!(baked, all);
+        }
+
+        #[test]
+        fn sequence_clips_stay_in_order() {
+            let id = ids(3);
+            let track = TrackFragment::new()
+                .upsert_sequence(
+                    key("a"),
+                    seq(&[
+                        clip(id[0], 0, 100),
+                        clip(id[1], 100, 100),
+                        clip(id[2], 200, 100),
+                    ]),
+                )
+                .compile();
+
+            assert_eq!(baked(&track), [id[0], id[1], id[2]]);
+        }
+
+        #[test]
+        fn empty_track_has_no_bake_order() {
+            let track = TrackFragment::new().compile();
+            assert_eq!(track.bake_clips().count(), 0);
+        }
     }
 }

--- a/crates/motiongfx/src/track.rs
+++ b/crates/motiongfx/src/track.rs
@@ -8,6 +8,8 @@ use nonempty::NonEmpty;
 
 use crate::action::{ActionClip, ActionId, ActionKey, paths_alias};
 use crate::sequence::Sequence;
+#[cfg(feature = "diagnostics")]
+use crate::time::Range;
 
 pub trait TrackOrdering {
     /// Run all [`TrackFragment`]s one after another.
@@ -214,6 +216,9 @@ impl TrackFragment {
         let mut sequences =
             self.sequences.into_iter().collect::<Vec<_>>();
 
+        #[cfg(feature = "diagnostics")]
+        let conflicts = resolve_conflicts(&mut sequences);
+        #[cfg(not(feature = "diagnostics"))]
         resolve_conflicts(&mut sequences);
 
         if sequences.is_empty() {
@@ -222,6 +227,8 @@ impl TrackFragment {
                 sequence_spans: Box::new([]),
                 clip_arena: Box::new([]),
                 bake_order: Box::new([]),
+                #[cfg(feature = "diagnostics")]
+                conflicts,
                 duration: self.duration,
             };
         }
@@ -302,6 +309,8 @@ impl TrackFragment {
             sequence_spans: sequence_spans.into_boxed_slice(),
             clip_arena,
             bake_order,
+            #[cfg(feature = "diagnostics")]
+            conflicts,
             duration,
         }
     }
@@ -313,11 +322,35 @@ impl Default for TrackFragment {
     }
 }
 
+/// A clip dropped when the track compiled because a later action on
+/// an aliasing field path of the same subject overlapped it.
+#[cfg(feature = "diagnostics")]
+#[derive(Debug, Clone, Copy)]
+pub struct FieldConflict {
+    pub dropped: ActionId,
+    pub dropped_field: UntypedField,
+    /// Time span of the dropped clip.
+    pub dropped_span: Range,
+    pub winner: ActionId,
+    pub winner_field: UntypedField,
+    /// Where the two clips overlapped.
+    pub overlap: Range,
+}
+
+#[cfg(feature = "diagnostics")]
+type ConflictReport = Box<[FieldConflict]>;
+#[cfg(not(feature = "diagnostics"))]
+type ConflictReport = ();
+
 /// Drops any clip that a later-authored action on an aliasing field
 /// path of the same subject overlaps in time. The later action wins
 /// the whole clip, not just the overlapped span.
-fn resolve_conflicts(sequences: &mut Vec<(ActionKey, Sequence)>) {
+fn resolve_conflicts(
+    sequences: &mut Vec<(ActionKey, Sequence)>,
+) -> ConflictReport {
     let mut removed = HashSet::<ActionId>::new();
+    #[cfg(feature = "diagnostics")]
+    let mut conflicts = Vec::new();
 
     for (i, (ka, sa)) in sequences.iter().enumerate() {
         for (j, (kb, sb)) in sequences.iter().enumerate() {
@@ -339,6 +372,21 @@ fn resolve_conflicts(sequences: &mut Vec<(ActionKey, Sequence)>) {
                         && cb.start < ca.end()
                         && removed.insert(ca.id)
                     {
+                        #[cfg(feature = "diagnostics")]
+                        conflicts.push(FieldConflict {
+                            dropped: ca.id,
+                            dropped_field: *ka.field(),
+                            dropped_span: Range {
+                                start: ca.start,
+                                end: ca.end(),
+                            },
+                            winner: cb.id,
+                            winner_field: *kb.field(),
+                            overlap: Range {
+                                start: ca.start.max(cb.start),
+                                end: ca.end().min(cb.end()),
+                            },
+                        });
                         #[cfg(feature = "tracing")]
                         tracing::warn!(
                             "dropping action on `{}` ({:?}..{:?}): a later action on `{}` overlaps it",
@@ -353,26 +401,29 @@ fn resolve_conflicts(sequences: &mut Vec<(ActionKey, Sequence)>) {
         }
     }
 
-    if removed.is_empty() {
-        return;
+    if !removed.is_empty() {
+        sequences.retain_mut(|(_, seq)| {
+            let kept = seq
+                .clips
+                .iter()
+                .copied()
+                .filter(|clip| !removed.contains(&clip.id))
+                .collect::<Vec<_>>();
+
+            match NonEmpty::from_vec(kept) {
+                Some(clips) => {
+                    seq.clips = clips;
+                    true
+                }
+                None => false,
+            }
+        });
     }
 
-    sequences.retain_mut(|(_, seq)| {
-        let kept = seq
-            .clips
-            .iter()
-            .copied()
-            .filter(|clip| !removed.contains(&clip.id))
-            .collect::<Vec<_>>();
-
-        match NonEmpty::from_vec(kept) {
-            Some(clips) => {
-                seq.clips = clips;
-                true
-            }
-            None => false,
-        }
-    });
+    #[cfg(feature = "diagnostics")]
+    {
+        conflicts.into_boxed_slice()
+    }
 }
 
 /// A compiled dense action sequences, optimized for playback and
@@ -402,6 +453,11 @@ pub struct Track {
 
     /// `clip_arena` indices in start-time order, ties by `ActionId`.
     bake_order: Box<[u32]>,
+
+    /// Clips this track dropped to resolve overlapping actions on
+    /// aliasing field paths.
+    #[cfg(feature = "diagnostics")]
+    conflicts: Box<[FieldConflict]>,
 
     /// Total duration of the track.
     ///
@@ -455,6 +511,14 @@ impl Track {
     #[inline]
     pub fn duration(&self) -> Duration {
         self.duration
+    }
+
+    /// Clips this track dropped to resolve overlapping actions on
+    /// aliasing field paths.
+    #[cfg(feature = "diagnostics")]
+    #[inline]
+    pub fn conflicts(&self) -> &[FieldConflict] {
+        &self.conflicts
     }
 }
 
@@ -775,7 +839,7 @@ mod tests {
         );
     }
 
-    mod bake_order {
+    mod compile {
         use typarena::id::IdGenerator;
 
         use crate::action::ActionMarker;
@@ -895,6 +959,55 @@ mod tests {
         fn empty_track_has_no_bake_order() {
             let track = TrackFragment::new().compile();
             assert_eq!(track.bake_clips().count(), 0);
+        }
+
+        #[test]
+        fn overlapping_aliasing_actions_drop_the_earlier() {
+            let id = ids(2);
+            // `""` (the source) aliases `::x`; the later clip overlaps.
+            let track = TrackFragment::new()
+                .upsert_sequence(
+                    key(""),
+                    seq(&[clip(id[0], 0, 100)]),
+                )
+                .upsert_sequence(
+                    key("::x"),
+                    seq(&[clip(id[1], 50, 100)]),
+                )
+                .compile();
+
+            assert_eq!(baked(&track), [id[1]]);
+        }
+
+        #[cfg(feature = "diagnostics")]
+        #[test]
+        fn conflicts_report_the_dropped_and_winning_clips() {
+            use crate::time::{Range, cs};
+
+            let id = ids(2);
+            let track = TrackFragment::new()
+                .upsert_sequence(
+                    key(""),
+                    seq(&[clip(id[0], 0, 100)]),
+                )
+                .upsert_sequence(
+                    key("::x"),
+                    seq(&[clip(id[1], 50, 100)]),
+                )
+                .compile();
+
+            let conflicts = track.conflicts();
+            assert_eq!(conflicts.len(), 1);
+            assert_eq!(conflicts[0].dropped, id[0]);
+            assert_eq!(conflicts[0].winner, id[1]);
+            assert_eq!(
+                conflicts[0].dropped_span,
+                Range { start: cs(0), end: cs(100) },
+            );
+            assert_eq!(
+                conflicts[0].overlap,
+                Range { start: cs(50), end: cs(100) },
+            );
         }
     }
 }

--- a/crates/motiongfx/tests/field_composition.rs
+++ b/crates/motiongfx/tests/field_composition.rs
@@ -54,10 +54,7 @@ fn lerp_vec3(from: &Vec3, to: &Vec3, t: f32) -> Vec3 {
 
 fn world_starting_at(translation: Vec3) -> World {
     World {
-        subjects: HashMap::from([(
-            CUBE,
-            Transform { translation },
-        )]),
+        subjects: HashMap::from([(CUBE, Transform { translation })]),
     }
 }
 
@@ -91,17 +88,26 @@ fn sub_field_then_whole_field_composes() {
             .with_interp(lerp_f32)
             .play(s(2)),
         builder
-            .act_builder(CUBE, path!(<Transform>::translation), |_| {
-                Vec3 { x: 3.0, y: 1.0, z: 2.0 }
-            })
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation),
+                |_| Vec3 {
+                    x: 3.0,
+                    y: 1.0,
+                    z: 2.0,
+                },
+            )
             .with_interp(lerp_vec3)
             .play(s(2)),
     ]
     .ord_chain();
 
     let mut timeline = builder.compile(track.compile());
-    let mut world =
-        world_starting_at(Vec3 { x: 0.0, y: 1.0, z: 0.0 });
+    let mut world = world_starting_at(Vec3 {
+        x: 0.0,
+        y: 1.0,
+        z: 0.0,
+    });
     timeline.bake_actions(&registry, &world);
 
     // Step past `translation::x` so only the whole-`translation` clip
@@ -126,9 +132,15 @@ fn whole_field_then_sub_field_composes() {
 
     let track = [
         builder
-            .act_builder(CUBE, path!(<Transform>::translation), |_| {
-                Vec3 { x: 5.0, y: 5.0, z: 5.0 }
-            })
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation),
+                |_| Vec3 {
+                    x: 5.0,
+                    y: 5.0,
+                    z: 5.0,
+                },
+            )
             .with_interp(lerp_vec3)
             .play(s(2)),
         builder
@@ -218,9 +230,15 @@ fn overlapping_whole_and_sub_field_drops_the_earlier() {
 
     let track = [
         builder
-            .act_builder(CUBE, path!(<Transform>::translation), |_| {
-                Vec3 { x: 5.0, y: 5.0, z: 5.0 }
-            })
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation),
+                |_| Vec3 {
+                    x: 5.0,
+                    y: 5.0,
+                    z: 5.0,
+                },
+            )
             .with_interp(lerp_vec3)
             .play(s(4)),
         builder

--- a/crates/motiongfx/tests/field_composition.rs
+++ b/crates/motiongfx/tests/field_composition.rs
@@ -174,6 +174,60 @@ fn whole_field_then_sub_field_composes() {
     );
 }
 
+/// A seek that lands inside a later `translation::x` clip while the
+/// earlier whole-`translation` clip resolves to its end in the same
+/// pass. The `x` slide is newer and wins, whichever pipeline samples
+/// first.
+#[test]
+fn boundary_crossing_seek_applies_child_alias_last() {
+    let mut registry = Registry::new();
+    let mut builder = registry.create_builder::<World>();
+
+    let track = [
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation),
+                |_| Vec3 {
+                    x: 2.0,
+                    y: 5.0,
+                    z: 5.0,
+                },
+            )
+            .with_interp(lerp_vec3)
+            .play(s(2)),
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation::x),
+                |_| 9.0,
+            )
+            .with_interp(lerp_f32)
+            .play(s(2)),
+    ]
+    .ord_chain();
+
+    let mut timeline = builder.compile(track.compile());
+    let mut world = world_starting_at(Vec3::default());
+    timeline.bake_actions(&registry, &world);
+
+    // From t = 0 straight to t = 3: past the whole-`translation` clip
+    // [0, 2] (-> its end) and halfway through `translation::x` [2, 4].
+    let translation =
+        sample_at(&registry, &mut timeline, &mut world, s(3));
+
+    assert!(
+        (translation.x - 5.5).abs() < 1e-3,
+        "x eases 2 -> 9 and is not clobbered by `translation`'s end, got {}",
+        translation.x,
+    );
+    assert!(
+        (translation.y - 5.0).abs() < 1e-3
+            && (translation.z - 5.0).abs() < 1e-3,
+        "y and z hold where `translation` ended, got {translation:?}",
+    );
+}
+
 /// `translation::x` and `translation::y` fully overlap in time but do
 /// not alias, so both run.
 #[test]

--- a/crates/motiongfx/tests/field_composition.rs
+++ b/crates/motiongfx/tests/field_composition.rs
@@ -1,0 +1,254 @@
+//! Actions on overlapping field paths of one subject: non-conflicting
+//! ones compose through baking, conflicting ones drop the earlier at
+//! compile.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use motiongfx::prelude::*;
+
+const CUBE: u32 = 0;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+struct Vec3 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Transform {
+    translation: Vec3,
+}
+
+#[derive(Default)]
+struct World {
+    subjects: HashMap<u32, Transform>,
+}
+
+impl SubjectSource<u32, Transform> for World {
+    fn get_source(&self, id: u32) -> Option<&Transform> {
+        self.subjects.get(&id)
+    }
+
+    fn apply_source<R>(
+        &mut self,
+        id: u32,
+        f: impl FnOnce(&mut Transform) -> R,
+    ) -> Option<R> {
+        self.subjects.get_mut(&id).map(f)
+    }
+}
+
+fn lerp_f32(from: &f32, to: &f32, t: f32) -> f32 {
+    from + (to - from) * t
+}
+
+fn lerp_vec3(from: &Vec3, to: &Vec3, t: f32) -> Vec3 {
+    Vec3 {
+        x: lerp_f32(&from.x, &to.x, t),
+        y: lerp_f32(&from.y, &to.y, t),
+        z: lerp_f32(&from.z, &to.z, t),
+    }
+}
+
+fn world_starting_at(translation: Vec3) -> World {
+    World {
+        subjects: HashMap::from([(
+            CUBE,
+            Transform { translation },
+        )]),
+    }
+}
+
+fn sample_at(
+    registry: &Registry,
+    timeline: &mut Timeline<World>,
+    world: &mut World,
+    time: Duration,
+) -> Vec3 {
+    timeline.set_target_time(time);
+    timeline.queue_actions();
+    timeline.sample_queued_actions(registry, world);
+    world.subjects[&CUBE].translation
+}
+
+/// `translation::x` then a chained (non-overlapping) whole
+/// `translation`. The second action bakes its start from the composed
+/// `x`, so `x` eases from 6, not from the initial 0.
+#[test]
+fn sub_field_then_whole_field_composes() {
+    let mut registry = Registry::new();
+    let mut builder = registry.create_builder::<World>();
+
+    let track = [
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation::x),
+                |_| 6.0,
+            )
+            .with_interp(lerp_f32)
+            .play(s(2)),
+        builder
+            .act_builder(CUBE, path!(<Transform>::translation), |_| {
+                Vec3 { x: 3.0, y: 1.0, z: 2.0 }
+            })
+            .with_interp(lerp_vec3)
+            .play(s(2)),
+    ]
+    .ord_chain();
+
+    let mut timeline = builder.compile(track.compile());
+    let mut world =
+        world_starting_at(Vec3 { x: 0.0, y: 1.0, z: 0.0 });
+    timeline.bake_actions(&registry, &world);
+
+    // Step past `translation::x` so only the whole-`translation` clip
+    // is live, then land halfway through it.
+    sample_at(&registry, &mut timeline, &mut world, cs(210));
+    let translation =
+        sample_at(&registry, &mut timeline, &mut world, s(3));
+
+    assert!(
+        (translation.x - 4.5).abs() < 1e-3,
+        "x should ease 6 -> 3, got {}",
+        translation.x,
+    );
+}
+
+/// Whole `translation` then a chained `translation::x`. `translation::x`
+/// bakes its start from where `translation` left `x`.
+#[test]
+fn whole_field_then_sub_field_composes() {
+    let mut registry = Registry::new();
+    let mut builder = registry.create_builder::<World>();
+
+    let track = [
+        builder
+            .act_builder(CUBE, path!(<Transform>::translation), |_| {
+                Vec3 { x: 5.0, y: 5.0, z: 5.0 }
+            })
+            .with_interp(lerp_vec3)
+            .play(s(2)),
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation::x),
+                |_| 9.0,
+            )
+            .with_interp(lerp_f32)
+            .play(s(2)),
+    ]
+    .ord_chain();
+
+    let mut timeline = builder.compile(track.compile());
+    let mut world = world_starting_at(Vec3::default());
+    timeline.bake_actions(&registry, &world);
+
+    sample_at(&registry, &mut timeline, &mut world, cs(210));
+    let translation =
+        sample_at(&registry, &mut timeline, &mut world, s(3));
+
+    assert!(
+        (translation.x - 7.0).abs() < 1e-3,
+        "x should ease 5 -> 9, got {}",
+        translation.x,
+    );
+    assert!(
+        (translation.y - 5.0).abs() < 1e-3
+            && (translation.z - 5.0).abs() < 1e-3,
+        "y and z hold where `translation` left them, got {translation:?}",
+    );
+}
+
+/// `translation::x` and `translation::y` fully overlap in time but do
+/// not alias, so both run.
+#[test]
+fn sibling_sub_fields_do_not_conflict() {
+    let mut registry = Registry::new();
+    let mut builder = registry.create_builder::<World>();
+
+    let track = [
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation::x),
+                |_| 6.0,
+            )
+            .with_interp(lerp_f32)
+            .play(s(4)),
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation::y),
+                |_| 8.0,
+            )
+            .with_interp(lerp_f32)
+            .play(s(4)),
+    ]
+    .ord_all();
+
+    let mut timeline = builder.compile(track.compile());
+    let mut world = world_starting_at(Vec3::default());
+    timeline.bake_actions(&registry, &world);
+
+    let translation =
+        sample_at(&registry, &mut timeline, &mut world, s(2));
+
+    assert!(
+        (translation.x - 3.0).abs() < 1e-3,
+        "x eases 0 -> 6: {}",
+        translation.x,
+    );
+    assert!(
+        (translation.y - 4.0).abs() < 1e-3,
+        "y eases 0 -> 8: {}",
+        translation.y,
+    );
+}
+
+/// Whole `translation` then an overlapping `translation::x`. The
+/// `translation` clip is dropped at compile, so only the `x` slide
+/// runs and `y`/`z` never move.
+#[test]
+fn overlapping_whole_and_sub_field_drops_the_earlier() {
+    let mut registry = Registry::new();
+    let mut builder = registry.create_builder::<World>();
+
+    let track = [
+        builder
+            .act_builder(CUBE, path!(<Transform>::translation), |_| {
+                Vec3 { x: 5.0, y: 5.0, z: 5.0 }
+            })
+            .with_interp(lerp_vec3)
+            .play(s(4)),
+        builder
+            .act_builder(
+                CUBE,
+                path!(<Transform>::translation::x),
+                |_| 9.0,
+            )
+            .with_interp(lerp_f32)
+            .play(s(2)),
+    ]
+    .ord_flow(s(1));
+
+    let mut timeline = builder.compile(track.compile());
+    let mut world = world_starting_at(Vec3::default());
+    timeline.bake_actions(&registry, &world);
+
+    // The surviving `translation::x` clip is [1, 3]; halfway is t = 2.
+    let translation =
+        sample_at(&registry, &mut timeline, &mut world, s(2));
+
+    assert!(
+        (translation.x - 4.5).abs() < 1e-3,
+        "x eases 0 -> 9: {}",
+        translation.x,
+    );
+    assert!(
+        translation.y == 0.0 && translation.z == 0.0,
+        "`translation`'s y/z motion was dropped, got {translation:?}",
+    );
+}

--- a/crates/motiongfx_scene/Cargo.toml
+++ b/crates/motiongfx_scene/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 default = ["std"]
 std = ["serde/std", "motiongfx/std"]
 tracing = ["motiongfx/tracing"]
+diagnostics = ["motiongfx/diagnostics"]
 
 [lints]
 workspace = true

--- a/crates/motiongfx_scene/Cargo.toml
+++ b/crates/motiongfx_scene/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 [features]
 default = ["std"]
 std = ["serde/std", "motiongfx/std"]
+tracing = ["motiongfx/tracing"]
 
 [lints]
 workspace = true

--- a/crates/motiongfx_scene/src/registry.rs
+++ b/crates/motiongfx_scene/src/registry.rs
@@ -59,7 +59,7 @@ where
     B::World: SubjectSource<I, S>,
     B::ValuePool: ValueColumn<B::ValueId, T>,
     I: SubjectId,
-    S: 'static,
+    S: Clone + ThreadSafe,
     T: ThreadSafe + Clone,
 {
     fn build(
@@ -170,7 +170,7 @@ fn register_field_accessor<B, S, T, I>(
     B: SceneBackend,
     B::World: SubjectSource<I, S>,
     I: SubjectId,
-    S: 'static,
+    S: Clone + ThreadSafe,
     T: ThreadSafe + Clone,
 {
     if let Some(field_acc) =
@@ -219,7 +219,7 @@ impl<B: SceneBackend> SceneRegistry<B> {
     where
         B::World: SubjectSource<B::Id, S>,
         B::ValuePool: ValueColumn<B::ValueId, T>,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: ThreadSafe + Clone,
     {
         self.register_field_with_key::<S, T, B::Id>(
@@ -241,7 +241,7 @@ impl<B: SceneBackend> SceneRegistry<B> {
         B::World: SubjectSource<I, S>,
         B::ValuePool: ValueColumn<B::ValueId, T>,
         I: SubjectId,
-        S: 'static,
+        S: Clone + ThreadSafe,
         T: ThreadSafe + Clone,
     {
         let field_ref =

--- a/examples/bevy_examples/examples/overlapping_fields.rs
+++ b/examples/bevy_examples/examples/overlapping_fields.rs
@@ -1,0 +1,164 @@
+//! Two actions on one `Transform` whose field paths overlap in memory
+//! (`translation` and `translation::x`).
+//!
+//! - top cube: the two actions are chained, so they never overlap in
+//!   time. Baking composes them: `translation::x` starts from the `x`
+//!   that `translation` left, so the motion is continuous.
+//! - bottom cube: the `translation::x` action overlaps `translation`
+//!   in time. At compile the `translation` clip is dropped entirely,
+//!   so the cube only does the x-slide and never rises.
+
+use core::time::Duration;
+
+use bevy::color::palettes::tailwind;
+use bevy::prelude::*;
+use bevy_examples::timeline_movement;
+use bevy_motiongfx::BevyMotionGfxPlugin;
+use bevy_motiongfx::prelude::*;
+
+const START: Vec3 = Vec3::new(-6.0, 0.0, 0.0);
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, BevyMotionGfxPlugin))
+        .add_systems(Startup, (setup, spawn_timeline))
+        .add_systems(Update, (timeline_movement, loop_timeline))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
+            clear_color: Color::from(tailwind::SLATE_900).into(),
+            ..default()
+        },
+        AmbientLight {
+            brightness: 400.0,
+            ..default()
+        },
+        Transform::from_xyz(1.0, 1.0, 20.0)
+            .looking_at(Vec3::new(1.0, 0.0, 0.0), Vec3::Y),
+    ));
+    commands.spawn((
+        DirectionalLight {
+            illuminance: 6_000.0,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 10.0, 8.0)
+            .looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    commands.spawn((
+        Text::new(
+            "top: chained translation then translation::x, baking composes them (continuous)\n\
+             bottom: overlapping translation::x removed the translation clip at compile\n\
+             space = play,  A/Left | D/Right = scrub",
+        ),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+    ));
+}
+
+fn spawn_cube(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<StandardMaterial>,
+    lane_y: f32,
+    color: Srgba,
+) -> Entity {
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Cuboid::from_length(1.8))),
+            MeshMaterial3d(
+                materials.add(StandardMaterial::from_color(color)),
+            ),
+            Transform::from_translation(
+                START + Vec3::new(0.0, lane_y, 0.0),
+            ),
+        ))
+        .id()
+}
+
+fn spawn_timeline(
+    mut commands: Commands,
+    mut motiongfx: ResMut<MotionGfxManager>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let compose = spawn_cube(
+        &mut commands,
+        &mut meshes,
+        &mut materials,
+        3.0,
+        tailwind::LIME_300,
+    );
+    let conflict = spawn_cube(
+        &mut commands,
+        &mut meshes,
+        &mut materials,
+        -3.0,
+        tailwind::ROSE_300,
+    );
+
+    let mut b = motiongfx.create_builder();
+    let ease = ease::cubic::ease_in_out;
+
+    // Top: chained, so no time overlap. `translation` lifts the cube,
+    // then `translation::x` continues x from the composed position.
+    let compose_track = [
+        b.act(compose, path!(<Transform>::translation), |_| {
+            START + Vec3::new(3.0, 6.0, 0.0)
+        })
+        .with_ease(ease)
+        .play(s(2)),
+        b.act(compose, path!(<Transform>::translation::x), |_| {
+            START.x + 10.0
+        })
+        .with_ease(ease)
+        .play(s(2)),
+    ]
+    .ord_chain();
+
+    // Bottom: `translation::x` starts one second in, overlapping
+    // `translation`. The `translation` clip is removed at compile.
+    let conflict_track = [
+        b.act(conflict, path!(<Transform>::translation), |_| {
+            START + Vec3::new(3.0, 6.0, 0.0)
+        })
+        .with_ease(ease)
+        .play(s(4)),
+        b.act(conflict, path!(<Transform>::translation::x), |_| {
+            START.x + 10.0
+        })
+        .with_ease(ease)
+        .play(s(3)),
+    ]
+    .ord_flow(s(1));
+
+    let track = [compose_track, conflict_track].ord_all().compile();
+    let timeline = b.compile(track);
+
+    commands.spawn((
+        motiongfx.add_timeline(timeline),
+        RealtimePlayer::new().with_playing(true),
+    ));
+}
+
+fn loop_timeline(
+    mut motiongfx: ResMut<MotionGfxManager>,
+    q_timelines: Query<&TimelineId>,
+) {
+    for id in &q_timelines {
+        if let Some(timeline) = motiongfx.get_timeline_mut(id)
+            && timeline.is_complete()
+        {
+            timeline.set_target_track(0);
+            timeline.set_target_time(Duration::ZERO);
+        }
+    }
+}

--- a/examples/vello_winit_example/examples/lissajous.rs
+++ b/examples/vello_winit_example/examples/lissajous.rs
@@ -38,12 +38,14 @@ fn lissajous_pt(
     )
 }
 
+#[derive(Clone)]
 struct GridLine {
     line: kurbo::Line,
     width: f64,
     color: Color,
 }
 
+#[derive(Clone)]
 struct CurveState {
     tracer: PathTracer,
 }


### PR DESCRIPTION
This PR fixes 2 major bugs in `motiongfx`:

### Bug 1: Action overlap

If you have a `translation::x` action spanning (0s..4s) and another same field path spanning (3s..5s), `motiongfx` will not be able to handle this overlapping gracefully. Previously this will cause `motiongfx` to panic, but we change it to soft warning in `0.3`, though the handing of it is non deterministic. This PR solves it by completely replacing overlapped actions with the newer action, so in this case, only the second action will survive the compile.

### Bug 2: Alias shadowing

If you have `translation::x` actions and `translation` actions, then, based on the original algorithm, each of these field paths will have their own sequence of segments. So during sampling, the sampler will sample 2 different values for the `x` value. And sometimes, if the `translation` sequence end up winning, the `translation::x` will be completely shadowed. This PR fixes that by making sure each actions are baked in insertion order, with the source value cloned & updated on every clip's bake. And because "bug 1" fixes the overlapping problem, we an be sure that no overlapping will interfere during this process.